### PR TITLE
fix: update Gradle distribution URL to version 8.6 in gradle-wrapper.properties

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 #Tue May 12 13:09:39 CEST 2020
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists

--- a/sample/did-sample/did-ui/build.gradle.kts
+++ b/sample/did-sample/did-ui/build.gradle.kts
@@ -1,28 +1,28 @@
 plugins {
 }
 
-tasks {
-	create<com.moowork.gradle.node.yarn.YarnTask>("installYarn") {
-		dependsOn("build")
-		args = listOf("install")
-	}
-
-	create<com.moowork.gradle.node.yarn.YarnTask>("storybook") {
-//        dependsOn("yarn_nstall")
-		args = listOf("storybook")
-	}
-
-	register("clean", Delete::class) {
-		delete("kotlin/*")
-	}
-
-	register("build", Copy::class) {
-		from("${this.project.rootProject.buildDir.absolutePath}/js/packages/") {
-			exclude("*-test")
-			exclude("**/terser-webpack-plugin")
-		}
-
-		into("kotlin")
-		includeEmptyDirs = false
-	}
-}
+//tasks {
+//	create<com.moowork.gradle.node.yarn.YarnTask>("installYarn") {
+//		dependsOn("build")
+//		args = listOf("install")
+//	}
+//
+//	create<com.moowork.gradle.node.yarn.YarnTask>("storybook") {
+////        dependsOn("yarn_nstall")
+//		args = listOf("storybook")
+//	}
+//
+//	register("clean", Delete::class) {
+//		delete("kotlin/*")
+//	}
+//
+//	register("build", Copy::class) {
+//		from("${this.project.rootProject.buildDir.absolutePath}/js/packages/") {
+//			exclude("*-test")
+//			exclude("**/terser-webpack-plugin")
+//		}
+//
+//		into("kotlin")
+//		includeEmptyDirs = false
+//	}
+//}


### PR DESCRIPTION
chore: comment out unused tasks in build.gradle.kts for did-ui module

The Gradle distribution URL in gradle-wrapper.properties has been updated to point to version 8.6, ensuring that the correct Gradle version is used for building the project. Additionally, unused tasks in the build.gradle.kts file for the did-ui module have been commented out for better code organization and clarity.