### PR TITLE
Add promote task

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -11,8 +11,10 @@ jobs:
     secrets:
       GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}
       GPG_SIGNING_PASSWORD: ${{ secrets.GPG_SIGNING_PASSWORD }}
-      PKG_MAVEN_USERNAME: ${{ secrets.PKG_MAVEN_USERNAME }}
-      PKG_MAVEN_TOKEN: ${{ secrets.PKG_MAVEN_TOKEN }}
+      PKG_GITHUB_USERNAME: ${{ secrets.PKG_GITHUB_USERNAME }}
+      PKG_GITHUB_TOKEN: ${{ secrets.PKG_GITHUB_TOKEN }}
+      PKG_SONATYPE_OSS_USERNAME: ${{ secrets.PKG_SONATYPE_OSS_USERNAME }}
+      PKG_SONATYPE_OSS_TOKEN: ${{ secrets.PKG_SONATYPE_OSS_TOKEN }}
 
   docs:
     uses: komune-io/fixers-gradle/.github/workflows/publish-storybook-workflow.yml@main

--- a/.github/workflows/sec.yml
+++ b/.github/workflows/sec.yml
@@ -7,8 +7,8 @@ jobs:
     uses: komune-io/fixers-gradle/.github/workflows/sec-workflow.yml@main
     secrets:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-      PKG_MAVEN_USERNAME: ${{ secrets.PKG_MAVEN_USERNAME }}
-      PKG_MAVEN_TOKEN: ${{ secrets.PKG_MAVEN_TOKEN }}
+      PKG_GITHUB_USERNAME: ${{ secrets.PKG_GITHUB_USERNAME }}
+      PKG_GITHUB_TOKEN: ${{ secrets.PKG_GITHUB_TOKEN }}
     permissions:
       contents: write
       pull-requests: read

--- a/Makefile
+++ b/Makefile
@@ -20,21 +20,21 @@ lint-libs:
 	#./gradlew detekt
 
 build-libs:
-	./gradlew build -x test publishToMavenLocal
+	VERSION=$(VERSION) ./gradlew clean build publishToMavenLocal -x test
 
 test-libs:
 	echo 'No Tests'
 #	./gradlew test
 
-publish-libs: build-libs
-	PKG_MAVEN_REPO=github ./gradlew publish
+publish-libs:
+	VERSION=$(VERSION) PKG_MAVEN_REPO=github ./gradlew publish --info
 
-promote-libs: build-libs
-	PKG_MAVEN_REPO=sonatype_oss ./gradlew publish
+promote-libs:
+	VERSION=$(VERSION) PKG_MAVEN_REPO=sonatype_oss ./gradlew publish
 
 .PHONY: version
 version:
-	echo "$$VERSION"
+	@echo "$(VERSION)"
 
 ## DEV ENVIRONMENT
 include infra/docker-compose/dev-compose.mk

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ lint-libs:
 	#./gradlew detekt
 
 build-libs:
-	VERSION=$(VERSION) ./gradlew clean build publishToMavenLocal -x test
+	VERSION=$(VERSION) ./gradlew clean build publishToMavenLocal --refresh-dependencies -x test
 
 test-libs:
 	echo 'No Tests'

--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,13 @@ STORYBOOK_NAME	   	 	:= komune/s2-storybook
 STORYBOOK_IMG	    	:= ${STORYBOOK_NAME}:${VERSION}
 STORYBOOK_LATEST		:= ${STORYBOOK_NAME}:latest
 
+VERSION = $(shell cat VERSION)
+
 lint: lint-libs
 build: build-libs
 test: test-libs
-package: package-libs
+publish: publish-libs
+promote: promote-libs
 
 libs: package-kotlin
 
@@ -23,11 +26,14 @@ test-libs:
 	echo 'No Tests'
 #	./gradlew test
 
-package-libs: build-libs
-	./gradlew  publish
+publish-libs: build-libs
+	PKG_MAVEN_REPO=github ./gradlew publish
 
+promote-libs: build-libs
+	PKG_MAVEN_REPO=sonatype_oss ./gradlew publish
+
+.PHONY: version
 version:
-	@VERSION=$$(cat VERSION); \
 	echo "$$VERSION"
 
 ## DEV ENVIRONMENT


### PR DESCRIPTION
ci(dev.yml, sec.yml, Makefile): update secrets for package repositories to use GitHub and Sonatype OSS credentials

The secrets for package repositories have been updated to use GitHub credentials (PKG_GITHUB_USERNAME and PKG_GITHUB_TOKEN) instead of Maven credentials (PKG_MAVEN_USERNAME and PKG_MAVEN_TOKEN). This change ensures that the correct credentials are used for the respective package repositories, improving security and access control. Additionally, in the Makefile, the targets `package-libs` and `publish-libs` have been renamed to `publish-libs` and `promote-libs` respectively to better reflect their actions.