### PR TITLE
build: update dependencies to use new group id 'io.komune.c2' instead of 'io.komune.ssm'

### DIFF
--- a/s2-automate/s2-automate-dsl/build.gradle.kts
+++ b/s2-automate/s2-automate-dsl/build.gradle.kts
@@ -7,5 +7,5 @@ plugins {
 }
 
 dependencies {
-    commonMainApi("io.komune.ssm:ssm-chaincode-dsl:${Versions.ssm}")
+    commonMainApi("io.komune.c2:ssm-chaincode-dsl:${Versions.ssm}")
 }

--- a/s2-spring/sourcing/s2-spring-boot-starter-sourcing-ssm/build.gradle.kts
+++ b/s2-spring/sourcing/s2-spring-boot-starter-sourcing-ssm/build.gradle.kts
@@ -9,6 +9,6 @@ dependencies {
 
 	Dependencies.Spring.autoConfigure(::implementation, ::kapt)
 
-	api("io.komune.ssm:ssm-data-spring-boot-starter:${Versions.ssm}")
-	api("io.komune.ssm:ssm-tx-spring-boot-starter:${Versions.ssm}")
+	api("io.komune.c2:ssm-data-spring-boot-starter:${Versions.ssm}")
+	api("io.komune.c2:ssm-tx-spring-boot-starter:${Versions.ssm}")
 }

--- a/s2-spring/storing/s2-spring-boot-starter-storing-ssm/build.gradle.kts
+++ b/s2-spring/storing/s2-spring-boot-starter-storing-ssm/build.gradle.kts
@@ -8,7 +8,7 @@ dependencies {
 	api(project(":s2-automate:s2-automate-core"))
 	api(project(":s2-spring:storing:s2-spring-boot-starter-storing"))
 
-	api("io.komune.ssm:ssm-data-spring-boot-starter:${Versions.ssm}")
-	api("io.komune.ssm:ssm-tx-spring-boot-starter:${Versions.ssm}")
-	api("io.komune.ssm:ssm-tx-init-ssm-spring-boot-starter:${Versions.ssm}")
+	api("io.komune.c2:ssm-data-spring-boot-starter:${Versions.ssm}")
+	api("io.komune.c2:ssm-tx-spring-boot-starter:${Versions.ssm}")
+	api("io.komune.c2:ssm-tx-init-ssm-spring-boot-starter:${Versions.ssm}")
 }


### PR DESCRIPTION
The dependencies in the build.gradle.kts files have been updated to use the new group id 'io.komune.c2' instead of 'io.komune.ssm'. This change ensures consistency and aligns the dependencies with the new group id for better organization and management of the project dependencies.