### PR TITLE
refactor(WithS2Id.kt, Loader.kt, SnapLoader.kt, SnapRepository.kt, SourcingViewExecutorImpl.kt, ViewLoader.kt, AutomateSourcingPersister.kt): change generic type constraints to include Any for ID parameter

### DIFF
--- a/s2-automate/s2-automate-dsl/src/commonMain/kotlin/s2/dsl/automate/model/WithS2Id.kt
+++ b/s2-automate/s2-automate-dsl/src/commonMain/kotlin/s2/dsl/automate/model/WithS2Id.kt
@@ -4,6 +4,6 @@ import kotlin.js.JsExport
 
 @JsExport
 interface WithS2Id<ID> {
-	fun s2Id(): ID
+	fun s2Id(): ID & Any
 }
 

--- a/s2-event-sourcing/s2-event-sourcing-dsl/src/commonMain/kotlin/s2/sourcing/dsl/Loader.kt
+++ b/s2-event-sourcing/s2-event-sourcing-dsl/src/commonMain/kotlin/s2/sourcing/dsl/Loader.kt
@@ -3,9 +3,9 @@ package s2.sourcing.dsl
 import kotlinx.coroutines.flow.Flow
 
 interface Loader<EVENT: Any, ENTITY, ID> {
-	suspend fun load(id: ID): ENTITY?
+	suspend fun load(id: ID & Any): ENTITY?
 	suspend fun load(events: Flow<EVENT>): ENTITY?
-	suspend fun loadAndEvolve(id: ID, news: Flow<EVENT>): ENTITY?
+	suspend fun loadAndEvolve(id: ID & Any, news: Flow<EVENT>): ENTITY?
 	suspend fun evolve(events: Flow<EVENT>, entity: ENTITY? = null): ENTITY?
 	suspend fun reloadHistory(): List<ENTITY>
 }

--- a/s2-event-sourcing/s2-event-sourcing-dsl/src/commonMain/kotlin/s2/sourcing/dsl/snap/SnapLoader.kt
+++ b/s2-event-sourcing/s2-event-sourcing-dsl/src/commonMain/kotlin/s2/sourcing/dsl/snap/SnapLoader.kt
@@ -14,11 +14,11 @@ EVENT: Evt,
 EVENT: WithS2Id<ID>,
 ENTITY: WithS2Id<ID> {
 
-	override suspend fun load(id: ID): ENTITY? {
+	override suspend fun load(id: ID & Any): ENTITY? {
 		return snapRepository.get(id) ?: viewLoader.load(id)
 	}
 
-	override suspend fun loadAndEvolve(id: ID, news: Flow<EVENT>): ENTITY? {
+	override suspend fun loadAndEvolve(id: ID & Any, news: Flow<EVENT>): ENTITY? {
 		return load(id).let { entity ->
 			viewLoader.evolve(news, entity)
 		}

--- a/s2-event-sourcing/s2-event-sourcing-dsl/src/commonMain/kotlin/s2/sourcing/dsl/snap/SnapRepository.kt
+++ b/s2-event-sourcing/s2-event-sourcing-dsl/src/commonMain/kotlin/s2/sourcing/dsl/snap/SnapRepository.kt
@@ -1,7 +1,7 @@
 package s2.sourcing.dsl.snap
 
 interface SnapRepository<ENTITY, ID> {
-	suspend fun get(id: ID): ENTITY?
-	suspend fun save(entity: ENTITY): ENTITY
-	suspend fun remove(id: ID): Boolean
+	suspend fun get(id: ID & Any): ENTITY?
+	suspend fun save(entity: ENTITY & Any): ENTITY
+	suspend fun remove(id: ID & Any): Boolean
 }

--- a/s2-event-sourcing/s2-event-sourcing-dsl/src/commonMain/kotlin/s2/sourcing/dsl/view/SourcingViewExecutorImpl.kt
+++ b/s2-event-sourcing/s2-event-sourcing-dsl/src/commonMain/kotlin/s2/sourcing/dsl/view/SourcingViewExecutorImpl.kt
@@ -12,7 +12,7 @@ class SourcingViewExecutorImpl< EVENT, ENTITY, ID>(
 EVENT: Evt,
 EVENT: WithS2Id<ID> {
 
-	suspend fun evolve(id: ID, msg: EVENT){
+	suspend fun evolve(id: ID & Any, msg: EVENT){
 		val entity = viewRepository.get(id) ?: viewBuilder.load(id)
 		evolver.evolve(msg, entity)
 	}

--- a/s2-event-sourcing/s2-event-sourcing-dsl/src/commonMain/kotlin/s2/sourcing/dsl/view/ViewLoader.kt
+++ b/s2-event-sourcing/s2-event-sourcing-dsl/src/commonMain/kotlin/s2/sourcing/dsl/view/ViewLoader.kt
@@ -25,7 +25,7 @@ open class ViewLoader<EVENT, ENTITY, ID>(
 EVENT: Evt,
 EVENT: WithS2Id<ID> {
 
-	override suspend fun load(id: ID): ENTITY? {
+	override suspend fun load(id: ID & Any): ENTITY? {
 		return eventRepository.load(id).let { events ->
 			load(events)
 		}
@@ -35,7 +35,7 @@ EVENT: WithS2Id<ID> {
 		return evolve(events, null)
 	}
 
-	override suspend fun loadAndEvolve(id: ID, news: Flow<EVENT>): ENTITY? {
+	override suspend fun loadAndEvolve(id: ID & Any, news: Flow<EVENT>): ENTITY? {
 		return eventRepository.load(id).let { events ->
 			load(events)
 		}.let { entity ->

--- a/s2-spring/sourcing/s2-spring-boot-starter-sourcing/src/main/kotlin/s2/spring/automate/sourcing/AutomateSourcingPersister.kt
+++ b/s2-spring/sourcing/s2-spring-boot-starter-sourcing/src/main/kotlin/s2/spring/automate/sourcing/AutomateSourcingPersister.kt
@@ -44,7 +44,7 @@ EVENT: WithS2Id<ID> {
         return persist(id, event)
     }
 
-    private suspend fun persist(id: ID, event: EVENT): ENTITY {
+    private suspend fun persist(id: ID & Any, event: EVENT): ENTITY {
         val entity = automateSourcingPersisterSnapChannel?.let { snapPersistChannel ->
             return snapPersistChannel.addToPersistQueue(id, event, ::persistSnap)
         } ?:  persistSnap(id, event)
@@ -52,7 +52,7 @@ EVENT: WithS2Id<ID> {
         eventStore.persist(event)
         return entity
     }
-    private suspend fun persistSnap(id: ID, event: EVENT): ENTITY {
+    private suspend fun persistSnap(id: ID & Any, event: EVENT): ENTITY {
         val entityMutated = projectionLoader.loadAndEvolve(id, flowOf(event))
             ?: throw ERROR_ENTITY_NOT_FOUND(event.s2Id().toString()).asException()
         return snapRepository?.save(entityMutated) ?: entityMutated


### PR DESCRIPTION
The changes were made to update the generic type constraints in various Kotlin files to include Any for the ID parameter. This change ensures that the ID parameter can accept any type, providing more flexibility and compatibility within the codebase.