### PR TITLE
build: add additional repositories to build.gradle.kts and buildSrc/build.gradle.kts for dependency resolution

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,6 +19,9 @@ plugins {
 allprojects {
 	group = "io.komune.s2"
 	version = System.getenv("VERSION") ?: "experimental-SNAPSHOT"
+	repositories {
+		defaultRepo()
+	}
 }
 
 

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -2,6 +2,11 @@ plugins {
 	`kotlin-dsl`
 }
 
+repositories {
+	mavenCentral()
+	maven { url = uri("https://s01.oss.sonatype.org/content/repositories/snapshots") }
+}
+
 dependencies {
 	implementation("io.komune.fixers.gradle:dependencies:0.18.0-SNAPSHOT")
 }

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -3,6 +3,8 @@ import io.komune.gradle.dependencies.FixersPluginVersions
 import io.komune.gradle.dependencies.FixersVersions
 import io.komune.gradle.dependencies.Scope
 import io.komune.gradle.dependencies.add
+import org.gradle.api.artifacts.dsl.RepositoryHandler
+import java.net.URI
 
 object PluginVersions {
 	val fixers = FixersPluginVersions.fixers
@@ -25,6 +27,12 @@ object Versions {
 	val f2 = FixersPluginVersions.fixers
 	val coroutines = FixersVersions.Kotlin.coroutines
 	val slf4j = FixersVersions.Logging.slf4j
+}
+
+fun RepositoryHandler.defaultRepo() {
+	mavenCentral()
+	maven { url = URI("https://s01.oss.sonatype.org/content/repositories/snapshots") }
+	maven { url = URI("https://repo.spring.io/milestone") }
 }
 
 object Dependencies {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,13 @@
 rootProject.name = "fixers-s2"
 
+pluginManagement {
+	repositories {
+		gradlePluginPortal()
+		mavenCentral()
+		maven { url = uri("https://s01.oss.sonatype.org/content/repositories/snapshots") }
+	}
+}
+
 include(
 	"s2-automate:s2-automate-core",
 	"s2-automate:s2-automate-documenter",


### PR DESCRIPTION
The changes were made to include additional repositories in the build.gradle.kts and buildSrc/build.gradle.kts files to ensure that the necessary dependencies can be resolved during the build process. By adding these repositories, the project can access a wider range of dependencies and plugins required for building and running the application.