### PR TITLE
refactor(EventSourcing.kt): replace java.util.Date with java.time.LocalDateTime for createdDate and lastModifiedDate fields

### DIFF
--- a/s2-spring/sourcing/s2-spring-boot-starter-sourcing-data/src/main/kotlin/s2/spring/sourcing/data/event/EventSourcing.kt
+++ b/s2-spring/sourcing/s2-spring-boot-starter-sourcing-data/src/main/kotlin/s2/spring/sourcing/data/event/EventSourcing.kt
@@ -6,7 +6,7 @@ import jakarta.persistence.Id
 import jakarta.persistence.MappedSuperclass
 import jakarta.persistence.Temporal
 import jakarta.persistence.TemporalType
-import java.util.Date
+import java.time.LocalDateTime
 import org.springframework.data.annotation.CreatedBy
 import org.springframework.data.annotation.CreatedDate
 import org.springframework.data.annotation.LastModifiedBy
@@ -24,11 +24,13 @@ class EventSourcing<ID>(
 	@CreatedBy
 	var createdBy: String? = null,
 	@CreatedDate
-	@Temporal(TemporalType.TIMESTAMP) var createdDate: Date? = null,
+	@Temporal(TemporalType.TIMESTAMP)
+	var createdDate: LocalDateTime? = null,
 	@LastModifiedBy
 	var lastModifiedBy: String? = null,
 	@LastModifiedDate
-	@Temporal(TemporalType.TIMESTAMP) var lastModifiedDate: Date? = null,
+	@Temporal(TemporalType.TIMESTAMP)
+	var lastModifiedDate: LocalDateTime? = null,
 	@Version
 	var version: Int? = null,
 )


### PR DESCRIPTION
The refactor is done to modernize the codebase by replacing the usage of java.util.Date with java.time.LocalDateTime for better handling of date and time information. This change aligns with best practices and improves the readability and maintainability of the code.