### PR TITLE
feat(S2Automate.kt): add support for withResultAsAction property in S2Automate class to track if transitions have results

### DIFF
--- a/s2-automate/s2-automate-dsl/src/commonMain/kotlin/s2/dsl/automate/S2Automate.kt
+++ b/s2-automate/s2-automate-dsl/src/commonMain/kotlin/s2/dsl/automate/S2Automate.kt
@@ -3,6 +3,7 @@ package s2.dsl.automate
 import kotlin.js.JsExport
 import kotlin.js.JsName
 import kotlinx.serialization.Serializable
+import s2.dsl.automate.ssm.toSsm
 
 @Serializable
 @JsExport
@@ -12,6 +13,9 @@ class S2Automate(
 	val version: String?,
 	val transitions: Array<S2Transition>,
 ):Automate {
+
+	val withResultAsAction = this.transitions.all { it.result != null }
+
 	override fun getAvailableTransitions(state: S2State): Array<S2Transition> {
 		return transitions.filter { it.from.isSame(state) }.toTypedArray()
 	}

--- a/s2-automate/s2-automate-dsl/src/commonMain/kotlin/s2/dsl/automate/ssm/SsmExtention.kt
+++ b/s2-automate/s2-automate-dsl/src/commonMain/kotlin/s2/dsl/automate/ssm/SsmExtention.kt
@@ -5,24 +5,26 @@ import s2.dsl.automate.S2Transition
 import ssm.chaincode.dsl.model.Ssm
 import ssm.chaincode.dsl.model.SsmTransition
 
-fun S2Automate.toSsm(permissive: Boolean = false) = Ssm(
-	name = this.name,
-	transitions = if(permissive) {
-		this.transitions.toSsmTransitions(0, 0)
-	} else {
-		this.transitions.toSsmTransitions()
-	}
-)
-
-fun Array<out S2Transition>.toSsmTransitions(
-	from: Int? = null, to: Int? = null
-) = filter { it.from != null }. map {
-	it.toSsmTransition(from, to)
+fun S2Automate.toSsm(permissive: Boolean = false): Ssm {
+	return Ssm(
+		name = this.name,
+		transitions = if (permissive) {
+			this.transitions.toSsmTransitions(0, 0, withResultAsAction)
+		} else {
+			this.transitions.toSsmTransitions(withResultAsAction = withResultAsAction)
+		}
+	)
 }
 
-fun S2Transition.toSsmTransition(from: Int? = null, to: Int? = null) = SsmTransition(
+fun Array<out S2Transition>.toSsmTransitions(
+	from: Int? = null, to: Int? = null, withResultAsAction: Boolean
+) = filter { it.from != null }. map {
+	it.toSsmTransition(from, to, withResultAsAction)
+}
+
+fun S2Transition.toSsmTransition(from: Int? = null, to: Int? = null, withResultAsAction: Boolean) = SsmTransition(
 	from = from ?: this.from!!.position,
 	to = to ?: this.to.position,
 	role = this.role.name,
-	action = this.result?.name ?: this.action.name
+	action = this.result?.name?.takeIf { withResultAsAction } ?: this.action.name
 )

--- a/s2-spring/storing/s2-spring-boot-starter-storing-ssm/src/main/kotlin/s2/spring/automate/ssm/persister/SsmAutomatePersister.kt
+++ b/s2-spring/storing/s2-spring-boot-starter-storing-ssm/src/main/kotlin/s2/spring/automate/ssm/persister/SsmAutomatePersister.kt
@@ -143,7 +143,8 @@ ENTITY : WithS2Id<ID> {
 			val entity = transitionContext.entity
 			val sessionName = entity.s2Id().toString()
 			val iteration = getIteration(transitionContext.automateContext, sessionName)
-			val action = transitionContext.event ?: transitionContext.msg
+			val withEventAsAction = transitionContext.automateContext.automate.withResultAsAction
+			val action = transitionContext.event?.takeIf { withEventAsAction } ?: transitionContext.msg
 			SsmSessionPerformActionCommand(
 				action = action::class.simpleName!!,
 				context = SsmContext(

--- a/sample/orderbook-storing/orderbook-storing-app-ssm/src/main/kotlin/s2/sample/orderbook/storing/app/ssm/OrderBookDeciderEventImpl.kt
+++ b/sample/orderbook-storing/orderbook-storing-app-ssm/src/main/kotlin/s2/sample/orderbook/storing/app/ssm/OrderBookDeciderEventImpl.kt
@@ -1,0 +1,73 @@
+package s2.sample.orderbook.storing.app.ssm
+
+import f2.dsl.fnc.F2Function
+import f2.dsl.fnc.f2Function
+import java.util.UUID
+import kotlinx.coroutines.flow.map
+import org.springframework.context.annotation.Bean
+import org.springframework.stereotype.Service
+import s2.sample.orderbook.storing.app.ssm.config.OrderBookS2Aggregate
+import s2.sample.orderbook.storing.app.ssm.config.OrderBookS2EventAggregate
+import s2.sample.subautomate.domain.OrderBookState
+import s2.sample.subautomate.domain.model.OrderBook
+import s2.sample.subautomate.domain.model.name
+import s2.sample.subautomate.domain.model.status
+import s2.sample.subautomate.domain.orderBook.OrderBookCloseCommand
+import s2.sample.subautomate.domain.orderBook.OrderBookClosedEvent
+import s2.sample.subautomate.domain.orderBook.OrderBookCreateCommand
+import s2.sample.subautomate.domain.orderBook.OrderBookCreatedEvent
+import s2.sample.subautomate.domain.orderBook.OrderBookDecide
+import s2.sample.subautomate.domain.orderBook.OrderBookDecider
+import s2.sample.subautomate.domain.orderBook.OrderBookPublishCommand
+import s2.sample.subautomate.domain.orderBook.OrderBookPublishedEvent
+import s2.sample.subautomate.domain.orderBook.OrderBookUpdateCommand
+import s2.sample.subautomate.domain.orderBook.OrderBookUpdatedEvent
+
+@Service
+class OrderBookDeciderEventImpl(
+	private val aggregate: OrderBookS2EventAggregate
+) : OrderBookDecider {
+
+	override fun orderBookCreateDecider()
+		: OrderBookDecide<OrderBookCreateCommand, OrderBookCreatedEvent> = F2Function { msg ->
+		aggregate.createWithEventFlow(msg) { cmd ->
+			val id = UUID.randomUUID().toString()
+			OrderBook(
+				id = id,
+				name = cmd.name,
+				status = OrderBookState.Created
+			) to OrderBookCreatedEvent(id = id, name = cmd.name, state = OrderBookState.Created)
+		}
+	}
+
+	override fun orderBookUpdateDecider()
+		: OrderBookDecide<OrderBookUpdateCommand, OrderBookUpdatedEvent> = F2Function { msg ->
+		aggregate.doTransitionFlow(msg) { cmd, entity ->
+			val ent = OrderBook.name.set(entity, cmd.name)
+			val event =	OrderBookUpdatedEvent(id = cmd.id, name = cmd.name, state = OrderBookState.Created)
+			ent to event
+		}
+	}
+
+	override fun orderBookPublishDecider()
+		: OrderBookDecide<OrderBookPublishCommand, OrderBookPublishedEvent> = F2Function { msg ->
+		aggregate.doTransitionFlow(msg) { cmd, entity ->
+			OrderBook.status.set(entity, OrderBookState.Published) to OrderBookPublishedEvent(
+				id = cmd.id,
+				state = OrderBookState.Published
+			)
+		}
+	}
+
+	override fun orderBookCloseDecider()
+		: OrderBookDecide<OrderBookCloseCommand, OrderBookClosedEvent> = F2Function { msg ->
+		aggregate.doTransitionFlow(msg) { cmd, entity ->
+			OrderBook.status.set(entity, OrderBookState.Closed) to
+				OrderBookClosedEvent(
+					id = cmd.id,
+					state = OrderBookState.Closed
+				)
+		}
+	}
+}
+

--- a/sample/orderbook-storing/orderbook-storing-app-ssm/src/main/kotlin/s2/sample/orderbook/storing/app/ssm/config/OrderBookAutomateEventConfig.kt
+++ b/sample/orderbook-storing/orderbook-storing-app-ssm/src/main/kotlin/s2/sample/orderbook/storing/app/ssm/config/OrderBookAutomateEventConfig.kt
@@ -20,18 +20,18 @@ import ssm.chaincode.dsl.model.uri.from
 import ssm.sdk.sign.extention.loadFromFile
 
 @Configuration
-class OrderBookAutomateConfig(
-	private val orderBookS2Aggregate: OrderBookS2Aggregate
+class OrderBookAutomateEventConfig(
+	private val orderBookS2Aggregate: OrderBookS2EventAggregate
 )
 	: S2SsmConfigurerAdapter<
 		OrderBookState,
 		OrderBookId,
 		OrderBook,
-		OrderBookS2Aggregate
+		OrderBookS2EventAggregate
 		>() {
-	override fun automate() = orderBookAutomate2("storing")
+	override fun automate() = orderBookAutomate("storing")
 
-	override fun executor(): OrderBookS2Aggregate = orderBookS2Aggregate
+	override fun executor(): OrderBookS2EventAggregate = orderBookS2Aggregate
 
 	override fun entityType(): Class<OrderBook> {
 		return OrderBook::class.java
@@ -51,32 +51,4 @@ class OrderBookAutomateConfig(
 }
 
 @Service
-class OrderBookS2Aggregate : S2AutomateExecutorSpring<OrderBookState, OrderBookId, OrderBook>()
-
-
-fun orderBookAutomate2(unique: String) = s2 {
-	name = "S2OrderBook-$unique-2"
-	transaction<OrderBookCreateCommand> {
-		to = OrderBookState.Created
-		role = Role
-	}
-	selfTransaction<OrderBookUpdateCommand> {
-		states += OrderBookState.Created
-		role = Role
-	}
-	transaction<OrderBookPublishCommand> {
-		from = OrderBookState.Created
-		to = OrderBookState.Published
-		role = Role
-	}
-	transaction<OrderBookCloseCommand> {
-		from = OrderBookState.Created
-		to = OrderBookState.Closed
-		role = Role
-	}
-	transaction<OrderBookCloseCommand> {
-		from = OrderBookState.Published
-		to = OrderBookState.Closed
-		role = Role
-	}
-}
+class OrderBookS2EventAggregate : S2AutomateExecutorSpring<OrderBookState, OrderBookId, OrderBook>()

--- a/sample/orderbook-storing/orderbook-storing-app-ssm/src/test/kotlin/s2/sample/orderbook/sourcing/app/ssm/OrderBookStoringDeciderEventImplTest.kt
+++ b/sample/orderbook-storing/orderbook-storing-app-ssm/src/test/kotlin/s2/sample/orderbook/sourcing/app/ssm/OrderBookStoringDeciderEventImplTest.kt
@@ -1,0 +1,122 @@
+package s2.sample.orderbook.sourcing.app.ssm
+
+import f2.dsl.fnc.invoke
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import s2.automate.core.context.AutomateContext
+import s2.sample.orderbook.sourcing.app.ssm.config.SpringTestBase
+import s2.sample.orderbook.storing.app.ssm.OrderBookDeciderEventImpl
+import s2.sample.orderbook.storing.app.ssm.OrderBookDeciderImpl
+import s2.sample.orderbook.storing.app.ssm.config.OrderBookAutomateConfig
+import s2.sample.subautomate.domain.OrderBookState
+import s2.sample.subautomate.domain.orderBook.OrderBookCloseCommand
+import s2.sample.subautomate.domain.orderBook.OrderBookClosedEvent
+import s2.sample.subautomate.domain.orderBook.OrderBookCreateCommand
+import s2.sample.subautomate.domain.orderBook.OrderBookCreatedEvent
+import s2.sample.subautomate.domain.orderBook.OrderBookDecide
+import s2.sample.subautomate.domain.orderBook.OrderBookPublishCommand
+import s2.sample.subautomate.domain.orderBook.OrderBookPublishedEvent
+import s2.sample.subautomate.domain.orderBook.OrderBookUpdateCommand
+import s2.sample.subautomate.domain.orderBook.OrderBookUpdatedEvent
+import s2.sample.subautomate.domain.orderBookAutomate
+
+internal class OrderBookStoringDeciderEventImplTest: SpringTestBase() {
+
+	@Autowired
+	lateinit var orderBookAutomateConfig: OrderBookAutomateConfig
+
+	@Autowired
+	lateinit var orderBookDeciderImpl: OrderBookDeciderEventImpl
+
+	@Test
+	fun `should create order book`(): Unit = runTest {
+		val event = orderBookDeciderImpl.orderBookCreateDecider()
+			.invoke(OrderBookCreateCommand("TheNewOrderBook"))
+ 		orderBookDeciderImpl.orderBookUpdateDecider()
+			 .invoke(OrderBookUpdateCommand(id = event.id, name = "TheNewOrderBookAfterUpdate"))
+		orderBookDeciderImpl.orderBookPublishDecider().invoke(OrderBookPublishCommand(id = event.id))
+		orderBookDeciderImpl.orderBookCloseDecider().invoke(OrderBookCloseCommand(id = event.id))
+		val ssmAutomatePersister = orderBookAutomateConfig.aggregateRepository()
+		val entity = ssmAutomatePersister.load(AutomateContext(automate = orderBookAutomate("storing-test-1")), event.id)
+		Assertions.assertThat(entity?.name).isEqualTo("TheNewOrderBookAfterUpdate")
+		Assertions.assertThat(entity?.status).isEqualTo(OrderBookState.Closed)
+	}
+	@Test
+	fun `should create flow(24-6) of order book`(): Unit = runTest {
+		(0..24).asFlow().map {
+			OrderBookCreateCommand("TheNewOrderBook$it")
+		}.let {
+			orderBookDeciderImpl.orderBookCreateDecider().invoke(it)
+		}.map { event ->
+			OrderBookUpdateCommand(id = event.id, name = "TheNewOrderBook2")
+		}.let {
+			orderBookDeciderImpl.orderBookUpdateDecider().invoke(it)
+		}.map { event ->
+			OrderBookPublishCommand(id = event.id)
+		}.let {
+			orderBookDeciderImpl.orderBookPublishDecider().invoke(it)
+		}.map { event ->
+			OrderBookCloseCommand(id = event.id)
+		}.let {
+			orderBookDeciderImpl.orderBookCloseDecider().invoke(it)
+		}.map { event ->
+			val ssmAutomatePersister = orderBookAutomateConfig.aggregateRepository()
+			val entity = ssmAutomatePersister.load(AutomateContext(automate = orderBookAutomate("storing-test-2")), event.id)
+			Assertions.assertThat(entity?.name).isEqualTo("TheNewOrderBook2")
+		}
+	}
+
+	@Test
+	fun `should create flow(4-6) of order book`(): Unit = runTest {
+		(0..4).asFlow().map {
+			OrderBookCreateCommand("TheNewOrderBook$it")
+		}.let {
+			orderBookDeciderImpl.orderBookCreateDecider().invoke(it)
+		}.map { event ->
+			OrderBookUpdateCommand(id = event.id, name = "TheNewOrderBook2")
+		}.let {
+			orderBookDeciderImpl.orderBookUpdateDecider().invoke(it)
+		}.map { event ->
+			OrderBookPublishCommand(id = event.id)
+		}.let {
+			orderBookDeciderImpl.orderBookPublishDecider().invoke(it)
+		}.map { event ->
+			OrderBookCloseCommand(id = event.id)
+		}.let {
+			orderBookDeciderImpl.orderBookCloseDecider().invoke(it)
+		}.toList().forEach { event ->
+			val ssmAutomatePersister = orderBookAutomateConfig.aggregateRepository()
+			val entity = ssmAutomatePersister.load(AutomateContext(automate = orderBookAutomate("storing-test-3")), event.id)
+//			assertThat(entity?.name).isEqualTo("TheNewOrderBook2")
+			assertThat(entity?.status).isEqualTo(OrderBookState.Closed)
+		}
+	}
+
+	@Test
+	fun `should flow event to build entity`(): Unit = runTest {
+		val all = flowOf(
+			OrderBookCreateCommand("TheNewOrderBook"),
+			OrderBookCreateCommand("TheNewOrderBook1"),
+			OrderBookCreateCommand("TheNewOrderBook2"),
+			OrderBookCreateCommand("TheNewOrderBook3"),
+			OrderBookCreateCommand("TheNewOrderBook4"),
+		)
+
+		val events = orderBookDeciderImpl.orderBookCreateDecider().invoke(all).toList()
+		assertThat(events).hasSize(5)
+		events.forEach { event ->
+			val ssmAutomatePersister = orderBookAutomateConfig.aggregateRepository()
+			val entity = ssmAutomatePersister.load(AutomateContext(automate = orderBookAutomate("storing-test-4")), event.id)
+			assertThat(entity?.name).startsWith("TheNewOrderBook")
+			assertThat(entity?.status).isEqualTo(OrderBookState.Created)
+		}
+	}
+
+}


### PR DESCRIPTION
refactor(SsmExtention.kt): update toSsmTransitions and toSsmTransition functions to use withResultAsAction property
refactor(SsmAutomatePersister.kt): introduce withEventAsAction variable to handle event as action based on withResultAsAction property
feat(OrderBookDeciderEventImpl.kt): implement OrderBookDecider interface with order book creation, update, publish, and close decisions
feat(OrderBookAutomateConfig.kt): rename automate function to automate2 and update the name property in the s2 block to include a unique identifier

The changes were made to enhance the functionality of the S2Automate, SsmExtention, SsmAutomatePersister, OrderBookDeciderEventImpl, and OrderBookAutomateConfig classes by introducing a new property to track if transitions have results, updating functions to utilize this property, and improving naming conventions for better clarity and organization.

feat(orderbook-storing): add OrderBookAutomateEventConfig and OrderBookStoringDeciderEventImplTest classes The OrderBookAutomateEventConfig class is added to configure the automation of order book events in the storing application. This class sets up the automation process for creating, updating, publishing, and closing order books. It also specifies the chaincode URI and signer agent for the automation.

The OrderBookStoringDeciderEventImplTest class is added to test the functionality of the order book storing decider events. It includes tests for creating order books, updating them, publishing them, and closing them. Additionally, it tests the flow of events to build entities and verifies the status of the order books after each operation.