### PR TITLE
feat(Dependencies.kt): add new versions

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -27,6 +27,9 @@ object Versions {
 
 	const val postgresql = "42.7.3"
 	const val r2dbc = "1.0.5.RELEASE"
+	const val redisSpring = "3.2.0"
+	const val redisTestContainer = "2.2.2"
+	const val lettuce = "6.2.2.RELEASE"
 }
 
 fun RepositoryHandler.defaultRepo() {
@@ -66,8 +69,8 @@ object Dependencies {
 
 		fun redis(scope: Scope) = scope.add(
 			"org.springframework.boot:spring-boot-starter-data-redis-reactive:${Versions.springBoot}",
-			"com.redis:spring-lettucemod:3.2.0",
-			"io.lettuce:lettuce-core:6.2.2.RELEASE"
+			"com.redis:spring-lettucemod:${Versions.redisSpring}",
+			"io.lettuce:lettuce-core:${Versions.lettuce}"
 		)
 
 		fun mongo(scope: Scope) = scope.add(
@@ -92,7 +95,7 @@ object Dependencies {
 	fun testcontainersPostgres(scope: Scope, runtimeOnly: Scope) = scope.add(
 		"org.testcontainers:postgresql:${Versions.testcontainers}",
 		"org.testcontainers:r2dbc:${Versions.testcontainers}",
-		"com.redis:testcontainers-redis:2.2.2",
+		"com.redis:testcontainers-redis:${Versions.redisTestContainer}",
 	).also { testcontainers(scope) }
 		.also {
 			runtimeOnly.add(

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 #Tue May 12 13:09:39 CEST 2020
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists


### PR DESCRIPTION
build(gradle-wrapper.properties): update Gradle distribution URL to version 8.9 The commit introduces new versions for the Redis and Lettuce dependencies in the project. This update ensures that the project uses the latest versions of these libraries, potentially bringing in new features, improvements, and bug fixes. Additionally, the Gradle distribution URL is updated to version 8.9, ensuring that the project uses the specified version of Gradle for building and managing dependencies.