### PR TITLE
ci(dev.yml): add workflow_dispatch trigger to manually run the workflow

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -1,6 +1,7 @@
 name: Dev
 
 on:
+  workflow_dispatch:
   pull_request:
     types: [opened, synchronize, labeled]
   push:

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -1,7 +1,6 @@
 name: Dev
 
 on:
-  workflow_dispatch:
   pull_request:
     types: [opened, synchronize, labeled]
   push:
@@ -10,7 +9,17 @@ on:
       - 'release/*'
     tags:
       - '*'
-
+  workflow_dispatch:
+    inputs:
+      logLevel:
+        description: 'Log level'
+        required: true
+        default: 'warning'
+        type: choice
+        options:
+          - info
+          - warning
+          - debug
 jobs:
   libs:
     uses: komune-io/fixers-gradle/.github/workflows/make-jvm-workflow.yml@main

--- a/libs.mk
+++ b/libs.mk
@@ -6,6 +6,7 @@ lint:
 	./gradlew detekt
 
 build:
+	./gradlew :sample:did-sample:did-domain:dependencies
 	VERSION=$(VERSION) ./gradlew clean build publishToMavenLocal -x test
 
 test-pre:

--- a/libs.mk
+++ b/libs.mk
@@ -7,7 +7,7 @@ lint:
 
 build:
 	./gradlew :sample:did-sample:did-domain:dependencies
-	VERSION=$(VERSION) ./gradlew clean build publishToMavenLocal -x test
+	VERSION=$(VERSION) ./gradlew clean build publishToMavenLocal -x test --refresh-dependencies
 
 test-pre:
 	make dev up

--- a/libs.mk
+++ b/libs.mk
@@ -7,7 +7,7 @@ lint:
 
 build:
 	./gradlew :sample:did-sample:did-domain:dependencies
-	VERSION=$(VERSION) ./gradlew clean build publishToMavenLocal -x test --refresh-dependencies
+	VERSION=$(VERSION) ./gradlew clean build publishToMavenLocal -x test
 
 test-pre:
 	make dev up

--- a/libs.mk
+++ b/libs.mk
@@ -6,8 +6,7 @@ lint:
 	./gradlew detekt
 
 build:
-	./gradlew :sample:did-sample:did-domain:dependencies
-	VERSION=$(VERSION) ./gradlew clean build publishToMavenLocal -x test --refresh-dependencies
+	VERSION=$(VERSION) ./gradlew clean build publishToMavenLocal -x test
 
 test-pre:
 	make dev up


### PR DESCRIPTION
By adding the workflow_dispatch trigger, users can now manually run the workflow in addition to the existing triggers like pull_request and push. This provides more flexibility and control over when the workflow should be executed.