### PR TITLE
chore(dev.yml): remove unnecessary inputs section from workflow_dispatch event

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -10,16 +10,7 @@ on:
     tags:
       - '*'
   workflow_dispatch:
-    inputs:
-      logLevel:
-        description: 'Log level'
-        required: true
-        default: 'warning'
-        type: choice
-        options:
-          - info
-          - warning
-          - debug
+
 jobs:
   libs:
     uses: komune-io/fixers-gradle/.github/workflows/make-jvm-workflow.yml@main


### PR DESCRIPTION
The inputs section under the workflow_dispatch event was removed as it was unnecessary and not being used. This cleanup improves the readability and maintainability of the workflow file.