### PR TITLE
chore(build): conditionally include mavenLocal repository based on MAVEN_LOCAL_USE environment variable

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -5,7 +5,9 @@ plugins {
 repositories {
 	mavenCentral()
 	maven { url = uri("https://central.sonatype.com/repository/maven-snapshots") }
-	mavenLocal()
+	if(System.getenv("MAVEN_LOCAL_USE") == "true") {
+		mavenLocal()
+	}
 }
 
 dependencies {

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -35,8 +35,9 @@ object Versions {
 fun RepositoryHandler.defaultRepo() {
 	mavenCentral()
 	maven { url = URI("https://central.sonatype.com/repository/maven-snapshots") }
-	maven { url = URI("https://repo.spring.io/milestone") }
-	mavenLocal()
+	if(System.getenv("MAVEN_LOCAL_USE") == "true") {
+		mavenLocal()
+	}
 }
 
 object Dependencies {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -5,7 +5,9 @@ pluginManagement {
 		gradlePluginPortal()
 		mavenCentral()
 		maven { url = uri("https://central.sonatype.com/repository/maven-snapshots") }
-		mavenLocal()
+		if(System.getenv("MAVEN_LOCAL_USE") == "true") {
+			mavenLocal()
+		}
 	}
 }
 


### PR DESCRIPTION
The build configuration now conditionally includes the mavenLocal repository only if the MAVEN_LOCAL_USE environment variable is set to "true". This change allows for more flexible build setups, enabling developers to easily toggle the use of the local Maven repository without modifying the build script directly.