### PR TITLE
chore(ci): update GitHub Actions workflow for better readability and consistency

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -32,11 +32,12 @@ jobs:
       pages: write
       id-token: write
     with:
-      on-tag: 'stage_promote'
+      on-tag: 'stage promote'
       make-file: 'make_docs.mk'
       with-chromatic: false
-      storybook-dir: storybook
-      storybook-static-dir: storybook-static
+      base-dir: "storybook"
+      storybook-dir: "storybook"
+      storybook-static-dir: "storybook-static"
     secrets:
       NPM_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}


### PR DESCRIPTION
The tag for the deployment has been changed from 'stage_promote' to 'stage promote' for improved clarity. Additionally, the indentation and structure of the parameters have been adjusted to enhance readability and maintain consistency in the workflow configuration.