### PR TITLE
chore(make_libs.mk): rename state target to stage for clarity and consistency

### DIFF
--- a/make_libs.mk
+++ b/make_libs.mk
@@ -16,8 +16,8 @@ test-pre:
 test:
 	./gradlew test
 
-state:
-	VERSION=$(VERSION) ./gradlew state
+stage:
+	VERSION=$(VERSION) ./gradlew stage
 
 promote:
 	VERSION=$(VERSION) ./gradlew promote


### PR DESCRIPTION
The target name is changed from `state` to `stage` to better reflect its purpose and align with common terminology used in deployment processes. This improves clarity for developers working with the makefile.