### PR TITLE
chore(ci): add GPG and JReleaser credentials to GitHub Actions workflow for enhanced security and deployment capabilities

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -21,8 +21,13 @@ jobs:
       make-file: 'make_libs.mk'
       on-tag: 'promote'
     secrets:
+      GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}
+      GPG_SIGNING_PASSWORD: ${{ secrets.GPG_SIGNING_PASSWORD }}
       PKG_GITHUB_USERNAME: ${{ github.actor }}
       PKG_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      JRELEASER_MAVENCENTRAL_USERNAME: ${{ secrets.JRELEASER_MAVENCENTRAL_USERNAME }}
+      JRELEASER_MAVENCENTRAL_PASSWORD: ${{ secrets.JRELEASER_MAVENCENTRAL_PASSWORD }}
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
   docs:
     uses: komune-io/fixers-gradle/.github/workflows/publish-storybook-workflow.yml@main


### PR DESCRIPTION
The addition of GPG_SIGNING_KEY, GPG_SIGNING_PASSWORD, JRELEASER_MAVENCENTRAL_USERNAME, JRELEASER_MAVENCENTRAL_PASSWORD, and SONAR_TOKEN enhances the security of the CI/CD pipeline by allowing for secure signing and deployment of artifacts. This ensures that the releases are verified and can be published to Maven Central and analyzed by SonarQube.