### PR TITLE
docs: add CONTEXT.md (ubiquitous language)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,64 @@
+# fixers-s2 — Context
+
+S2 models **the lifecycle of a domain entity as a finite state machine**. It provides the DSL to define the state machine, the engine that executes transitions, and two interchangeable persistence strategies (event-sourced or state-stored) for landing the result.
+
+S2 sits directly on top of F2: the messages that drive transitions are F2's CQRS Commands and Events, refined with state-machine metadata.
+
+## Glossary
+
+### Automate
+
+The S2 term — borrowed from French — for a **finite state machine definition**: a name + an ordered set of valid `Transition`s between `State`s for one entity type. Treat "Automate" and "automaton" as synonyms in prose; **"Automate" is the canonical written form** because that is what the code, artifact names (`s2-automate-*`), and types (`S2Automate`) use. Plural: Automates.
+
+An Automate is a *definition*, not an instance. An instance of an entity following an Automate is just called the **aggregate** (using DDD vocabulary).
+
+### S2State
+
+A marker type for one position in an Automate. Implements `S2State` and carries a stable position index so the engine can compare ordering. Each Automate enumerates its States.
+
+### S2Transition
+
+A directed edge in the Automate: `(fromState, command, role) → (toState, event)`. Declared in the Automate DSL; executed by the engine when a matching Command arrives for an aggregate currently in `fromState`.
+
+### S2Command
+
+A request to drive an aggregate through a transition. Refines f2-dsl-cqrs's `Cmd` with a `WithId<ID>` aggregate identifier (`S2Command<ID> : Cmd, WithId<ID>`). The companion **S2InitCommand** is the special variant that creates the aggregate (no prior state).
+
+### S2Event
+
+The result of executing an S2Command. Refines f2-dsl-cqrs's `Evt` with the aggregate id and the resulting state type (`S2Event<STATE, ID> : Evt, WithId<ID>`). Two concrete wrappers:
+
+- **S2EventSuccess** — carries `from` and `to` states.
+- **S2EventError** — carries `from`, `to`, and an `S2Error`.
+
+### S2Role
+
+A permission marker attached to a Transition. Restricts who is allowed to trigger that transition; checked by the engine at command dispatch.
+
+### Decide
+
+The function `(Command, currentState) → Event` that holds the business logic for one Transition. Authored by the consumer; called by the engine.
+
+### Evolve
+
+Event-sourcing only: the function `(Event, entityOrNull) → entity` that rebuilds an aggregate by folding the event log. Not used in state-stored mode.
+
+### Loader
+
+The component that materialises an aggregate in its current state for the engine to inspect before dispatch. In sourcing mode it replays events through Evolve; in storing mode it loads the snapshot row from the database.
+
+### Persistence strategy: Sourcing vs Storing
+
+Same Automate, Command, State, and Event definitions in both cases; the difference is **how the current state is recovered**.
+
+- **Sourcing** (`s2-spring-boot-starter-sourcing`, `s2-event-sourcing-dsl`) — store every Event, replay through Evolve to rebuild the aggregate. Choose when an immutable audit log is required.
+- **Storing** (`s2-spring-boot-starter-storing`) — persist the current aggregate snapshot (MongoDB / R2DBC variants). Choose when the audit log is not load-bearing and you want simpler reads. No Evolve function in this mode.
+
+The choice is per-Automate and made at Spring autoconfigure time by picking which starter to depend on.
+
+## Cross-references
+
+- Inherits Command / Query / Event from [../fixers-f2/CONTEXT.md](../fixers-f2/CONTEXT.md).
+- Specialised further by [../fixers-c2/CONTEXT.md](../fixers-c2/CONTEXT.md) (SSM = Signing State Machine on Hyperledger Fabric — an Automate on a blockchain).
+- Used to model the file lifecycle in [../../connect/connect-fs/CONTEXT.md](../../connect/connect-fs/CONTEXT.md).
+- Layer position: [../../docs/adr/0001-submodule-dependency-layers.md](../../docs/adr/0001-submodule-dependency-layers.md).

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -8,53 +8,75 @@ S2 sits directly on top of F2: the messages that drive transitions are F2's CQRS
 
 ### Automate
 
-The S2 term — borrowed from French — for a **finite state machine definition**: a name + an ordered set of valid `Transition`s between `State`s for one entity type. Treat "Automate" and "automaton" as synonyms in prose; **"Automate" is the canonical written form** because that is what the code, artifact names (`s2-automate-*`), and types (`S2Automate`) use. Plural: Automates.
+The S2 term — borrowed from French — for a **finite state machine definition**: `S2Automate` (in `s2-automate-dsl`, package `s2.dsl.automate`) is a name, an optional version, and the set of valid `S2Transition`s between `S2State`s for one entity type. Treat "Automate" and "automaton" as synonyms in prose; **"Automate" is the canonical written form** because that is what the code, artifact names (`s2-automate-*`), and types (`S2Automate`) use. Plural: Automates. Automates can nest: `S2SubMachine` wraps an Automate with start/end triggers.
 
-An Automate is a *definition*, not an instance. An instance of an entity following an Automate is just called the **aggregate** (using DDD vocabulary).
+An Automate is a *definition*, not an instance. An instance of an entity following an Automate is just called the **aggregate** (using DDD vocabulary); aggregates expose their identity and current state through the `WithS2Id<ID>` / `WithS2State<STATE>` markers.
+
+_Avoid_: "state machine" / "FSM" as the term of art (fine as an explanation, as in the README, but the types and artifacts say Automate); "automata".
 
 ### S2State
 
-A marker type for one position in an Automate. Implements `S2State` and carries a stable position index so the engine can compare ordering. Each Automate enumerates its States.
+One position in an Automate: an interface with a single `val position: Int`, a stable index the engine uses to compare states (two states are "the same" when their positions match). Each Automate enumerates its States.
 
 ### S2Transition
 
-A directed edge in the Automate: `(fromState, command, role) → (toState, event)`. Declared in the Automate DSL; executed by the engine when a matching Command arrives for an aggregate currently in `fromState`.
+A directed edge in the Automate. Its real shape is `S2Transition(from, to, role, action, result)`: `from` — source state (nullable), `to` — target state, `role` — who may trigger it, `action` — the Command type that triggers it, `result` — the Event type it produces (optional). A transition with `from = null` is an **init transition** (creates the aggregate; the DSL also has a dedicated `S2InitTransition` type with `to`/`role`/`action`). Declared in the Automate DSL builder; the engine accepts a Command only if a transition whose `action` matches leaves the aggregate's current state.
 
 ### S2Command
 
-A request to drive an aggregate through a transition. Refines f2-dsl-cqrs's `Cmd` with a `WithId<ID>` aggregate identifier (`S2Command<ID> : Cmd, WithId<ID>`). The companion **S2InitCommand** is the special variant that creates the aggregate (no prior state).
+A request to drive an aggregate through a transition: `S2Command<ID> : Cmd, WithId<ID>`, where `Cmd` is S2's typealias for f2-dsl-cqrs's `Command` and `WithId<ID>` is S2's own identifier marker. The companion **S2InitCommand** creates the aggregate: it extends `Cmd` only — no id, because the aggregate does not exist yet.
 
 ### S2Event
 
-The result of executing an S2Command. Refines f2-dsl-cqrs's `Evt` with the aggregate id and the resulting state type (`S2Event<STATE, ID> : Evt, WithId<ID>`). Two concrete wrappers:
+The result of executing an S2Command: `S2Event<STATE, ID> : Evt, WithId<ID>` (`Evt` = f2's `Event`) adds the aggregate `id` and `type: STATE`, the state the aggregate lands in. Two standalone classes (implementing `Evt` directly, not `S2Event`) report transition outcomes:
 
-- **S2EventSuccess** — carries `from` and `to` states.
-- **S2EventError** — carries `from`, `to`, and an `S2Error`.
+- **S2EventSuccess** — `id`, the triggering command (`type`), and `from`/`to` states.
+- **S2EventError** — the same, plus an `error: S2Error` (type, description, date, payload).
 
 ### S2Role
 
-A permission marker attached to a Transition. Restricts who is allowed to trigger that transition; checked by the engine at command dispatch.
+A permission marker interface attached to every Transition, declaring who is allowed to trigger it. It is declarative metadata serialized with the Automate definition, left to consumers to enforce; the core engine's guards check state/transition validity, not roles.
+
+### Guard
+
+A condition the engine evaluates before and after each transition (`Guard` / `GuardVerifier` in s2-automate-core). The built-in `TransitionStateGuard` rejects a Command when no transition with a matching `action` leaves the aggregate's current state.
+
+### S2AutomateEngine
+
+The engine entry point (s2-automate-core): `create(initCommands, decide)` and `doTransition(commands, exec)` load the aggregate, run the Guards, execute the consumer's logic, and hand the result to an `AutomatePersister`. Consumers reach it through the Spring adapters `S2AutomateExecutorSpring` (storing) and `S2AutomateDeciderSpring` (sourcing).
 
 ### Decide
 
-The function `(Command, currentState) → Event` that holds the business logic for one Transition. Authored by the consumer; called by the engine.
+`Decide<COMMAND, EVENT>`: an `F2Function<COMMAND, EVENT>` holding the business logic that turns a Command into an Event. Defined in s2-event-sourcing-dsl but returned by both modes' `decide { }` / `transition(command) { }` builders, which the engine calls with the current aggregate in scope.
 
 ### Evolve
 
-Event-sourcing only: the function `(Event, entityOrNull) → entity` that rebuilds an aggregate by folding the event log. Not used in state-stored mode.
+The conceptual update step: applying an Event to a model to produce the next model (a `fun interface Evolve<EVENT, ENTITY> : F2Function<EVENT, ENTITY>` exists in s2-event-sourcing-dsl). In code the replay fold is `View.evolve`; state recovery by replay is not used in storing mode.
+
+### View
+
+Sourcing: `View<EVENT, ENTITY>` with `suspend fun evolve(event, model): ENTITY?` — the fold that rebuilds an aggregate (or a read projection) from its event log. `ViewLoader` applies it over an `EventRepository`.
 
 ### Loader
 
-The component that materialises an aggregate in its current state for the engine to inspect before dispatch. In sourcing mode it replays events through Evolve; in storing mode it loads the snapshot row from the database.
+Sourcing only: `Loader<EVENT, ENTITY, ID>` (s2-event-sourcing-dsl) materialises an aggregate in its current state. `ViewLoader` replays the event log through a View; `SnapLoader` reads a Snapshot first and falls back to replay. In storing mode, loading is done by the `AutomatePersister` instead.
+
+### Snapshot (Snap)
+
+Sourcing optimisation: a cached copy of the current aggregate kept in a `SnapRepository` so `SnapLoader` can skip full event replay. A Snapshot is a cache over the event log, not the source of truth — do not confuse it with Storing mode.
 
 ### Persistence strategy: Sourcing vs Storing
 
 Same Automate, Command, State, and Event definitions in both cases; the difference is **how the current state is recovered**.
 
-- **Sourcing** (`s2-spring-boot-starter-sourcing`, `s2-event-sourcing-dsl`) — store every Event, replay through Evolve to rebuild the aggregate. Choose when an immutable audit log is required.
-- **Storing** (`s2-spring-boot-starter-storing`) — persist the current aggregate snapshot (MongoDB / R2DBC variants). Choose when the audit log is not load-bearing and you want simpler reads. No Evolve function in this mode.
+- **Sourcing** (`s2-event-sourcing-dsl`, `s2-spring-boot-starter-sourcing`, event store via `s2-spring-boot-starter-sourcing-data` with `-mongodb` / `-r2dbc` variants) — store every Event, rebuild the aggregate by replay (View/Loader). Choose when an immutable audit log is required.
+- **Storing** (`s2-spring-boot-starter-storing`, Spring Data persistence via `s2-spring-boot-starter-storing-data`) — persist the current aggregate directly; the consumer returns the updated entity alongside the event (`S2AutomateStoringEvolver.doTransition`). Choose when the audit log is not load-bearing and you want simpler reads. No event replay in this mode.
 
-The choice is per-Automate and made at Spring autoconfigure time by picking which starter to depend on.
+The choice is per-Automate and made at Spring configure time by picking which starter (and `S2ConfigurerAdapter`) to depend on.
+
+### S2Documenter
+
+`s2-automate-documenter` serializes an `S2Automate` definition to JSON (`build/s2-documenter/<name>.json`) so automate documentation and diagrams can be generated from the real definition rather than by hand.
 
 ## Cross-references
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -12,7 +12,7 @@ The S2 term — borrowed from French — for a **finite state machine definition
 
 An Automate is a *definition*, not an instance. An instance of an entity following an Automate is just called the **aggregate** (using DDD vocabulary); aggregates expose their identity and current state through the `WithS2Id<ID>` / `WithS2State<STATE>` markers.
 
-_Avoid_: "state machine" / "FSM" as the term of art (fine as an explanation, as in the README, but the types and artifacts say Automate); "automata".
+*Avoid*: "state machine" / "FSM" as the term of art (fine as an explanation, as in the README, but the types and artifacts say Automate); "automata".
 
 ### S2State
 


### PR DESCRIPTION
Adds a top-level `CONTEXT.md` glossary covering fixers-s2's domain: Automate (kept as the canonical FSM term — code, artifact names, and types all use it), S2State, S2Transition, S2Command (refines f2-dsl-cqrs `Cmd` with a `WithId<ID>` aggregate identifier), S2Event (refines `Evt` with aggregate id + resulting state), S2Role, Decide, Evolve, Loader.

Frames Sourcing vs Storing as two persistence strategies over one Automate definition (audit log vs snapshot), chosen per aggregate at Spring autoconfig time.

Part of a coordinated documentation bootstrap across all eight Komune fixers/connect submodules. Cross-cutting vocabulary and dependency-layer DAG live in the `fixers-release` orchestrator (separate PR).

No code changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation for the finite-state-machine domain, including automates, states, transitions, commands, events, roles, guards, and execution flow.
  * Documented views, loaders, snapshots, persistence approaches, Spring integration, terminology, and related modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->