### PR TITLE
feat(automate): WithS2Iteration stamp method for load-time iteration injection

### DIFF
--- a/s2-automate/s2-automate-dsl/src/commonMain/kotlin/s2/dsl/automate/model/WithS2Iteration.kt
+++ b/s2-automate/s2-automate-dsl/src/commonMain/kotlin/s2/dsl/automate/model/WithS2Iteration.kt
@@ -10,7 +10,11 @@ interface WithS2Iteration {
 	 * Returns a copy of this entity stamped with [iteration]. Called by the
 	 * storing persister at load time to carry the on-chain iteration onto the
 	 * loaded entity, so the persist phase can reuse it instead of re-querying
-	 * the chain. Implementations should return a copy (e.g. `copy(iteration = iteration)`).
+	 * the chain.
+	 *
+	 * Implementations should return a copy via a covariant return type — declare
+	 * the concrete entity type so callers keep type information and avoid casts:
+	 * `override fun withS2Iteration(iteration: Int): MyEntity = copy(iteration = iteration)`.
 	 */
 	fun withS2Iteration(iteration: Int): WithS2Iteration
 }

--- a/s2-automate/s2-automate-dsl/src/commonMain/kotlin/s2/dsl/automate/model/WithS2Iteration.kt
+++ b/s2-automate/s2-automate-dsl/src/commonMain/kotlin/s2/dsl/automate/model/WithS2Iteration.kt
@@ -5,5 +5,13 @@ import kotlin.js.JsExport
 @JsExport
 interface WithS2Iteration {
 	fun s2Iteration(): Int
+
+	/**
+	 * Returns a copy of this entity stamped with [iteration]. Called by the
+	 * storing persister at load time to carry the on-chain iteration onto the
+	 * loaded entity, so the persist phase can reuse it instead of re-querying
+	 * the chain. Implementations should return a copy (e.g. `copy(iteration = iteration)`).
+	 */
+	fun withS2Iteration(iteration: Int): WithS2Iteration
 }
 


### PR DESCRIPTION
## What

Adds `withS2Iteration(iteration: Int): WithS2Iteration` to the `WithS2Iteration` interface.

## Why

The SSM storing persister (fixers-c2) currently issues **two** chain reads per perform batch: one to load the entity state, and a second purely to read the session's current `iteration` (needed to build the on-chain command). The iteration is already present in the logs fetched by the first read — it's just discarded.

This method lets the persister stamp that already-fetched iteration onto the loaded entity, so the persist phase reads it from memory (existing `WithS2Iteration` fast-path) instead of re-querying. Net: 2 reads → 1 per batch.

No default impl on purpose: a no-op default would silently ship a stale iteration (→ MVCC rejects). Implementers return a copy, e.g. `copy(iteration = iteration)`.

## Companion PRs
- fixers-c2: persister injection + consuming entity

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for stamping an entity with an iteration value, allowing it to carry forward the current iteration when loaded.
  * Improved consistency for iteration-aware entities without requiring an additional lookup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->