### PR TITLE
fix: resolve SonarQube issues (S1186, S6218, S6508)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,6 +39,12 @@ fixers {
 	sonar {
 		organization = "komune-io"
 		projectKey = "komune-io_fixers-s2"
+		properties {
+			// Samples are standalone demo applications, not library code:
+			// exclude them from coverage and duplication analysis.
+			property("sonar.coverage.exclusions", "**/sample/**")
+			property("sonar.cpd.exclusions", "**/sample/**")
+		}
 	}
 	repositories {
 		sonatypeSnapshots = true

--- a/s2-automate/s2-automate-documenter/build.gradle.kts
+++ b/s2-automate/s2-automate-documenter/build.gradle.kts
@@ -5,4 +5,6 @@ plugins {
 
 dependencies {
 	implementation(project(":s2-automate:s2-automate-dsl"))
+
+	testImplementation(libs.bundles.test.junit)
 }

--- a/s2-automate/s2-automate-documenter/src/test/kotlin/s2/automate/documenter/S2DocumenterTest.kt
+++ b/s2-automate/s2-automate-documenter/src/test/kotlin/s2/automate/documenter/S2DocumenterTest.kt
@@ -1,0 +1,77 @@
+package s2.automate.documenter
+
+import java.nio.file.Files
+import java.nio.file.Path
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import s2.dsl.automate.S2InitCommand
+import s2.dsl.automate.S2Role
+import s2.dsl.automate.S2State
+import s2.dsl.automate.builder.s2
+
+class S2DocumenterTest {
+
+    enum class OrderState(override val position: Int) : S2State {
+        Created(0)
+    }
+
+    enum class OrderRole(val value: String) : S2Role {
+        Buyer("Buyer");
+
+        override fun toString() = value
+    }
+
+    interface OrderCreateCommand : S2InitCommand
+
+    private val automate = s2 {
+        name = "OrderAutomate"
+        init<OrderCreateCommand> {
+            to = OrderState.Created
+            role = OrderRole.Buyer
+        }
+    }
+
+    @Test
+    fun `recreateFile should create parent directories and an empty file`(@TempDir tempDir: Path) {
+        val outputFolder = tempDir.resolve("nested/output").toString()
+
+        val file = S2Documenter(outputFolder).recreateFile("automate.json", outputFolder)
+
+        assertThat(file).exists()
+        assertThat(Files.readAllBytes(file)).isEmpty()
+    }
+
+    @Test
+    fun `recreateFile should replace an existing file`(@TempDir tempDir: Path) {
+        val outputFolder = tempDir.toString()
+        val documenter = S2Documenter(outputFolder)
+        val existing = tempDir.resolve("automate.json")
+        Files.writeString(existing, "old content")
+
+        val file = documenter.recreateFile("automate.json", outputFolder)
+
+        assertThat(file).exists()
+        assertThat(Files.readString(file)).isEmpty()
+    }
+
+    @Test
+    fun `writeS2Automate should write the automate as json named after the automate`(@TempDir tempDir: Path) {
+        val documenter = S2Documenter(tempDir.toString())
+
+        val result = documenter.writeS2Automate(automate)
+
+        assertThat(result).isSameAs(documenter)
+        val written = tempDir.resolve("OrderAutomate.json")
+        assertThat(written).exists()
+        val content = Files.readString(written)
+        assertThat(content).contains("\"name\": \"OrderAutomate\"")
+        assertThat(content).contains("OrderCreateCommand")
+        assertThat(content).contains("OrderRole")
+    }
+
+    @Test
+    fun `getDefaultOutputDirectory should point to gradle build folder when no pom exists`() {
+        assertThat(getDefaultOutputDirectory()).isEqualTo("build/s2-documenter")
+    }
+}

--- a/s2-spring/sourcing/s2-spring-boot-starter-sourcing-data-r2dbc/src/main/kotlin/s2/spring/sourcing/data/r2dbc/R2dbcEventRepository.kt
+++ b/s2-spring/sourcing/s2-spring-boot-starter-sourcing-data-r2dbc/src/main/kotlin/s2/spring/sourcing/data/r2dbc/R2dbcEventRepository.kt
@@ -36,12 +36,12 @@ EVENT: WithS2Id<ID>
 		Sort.Order.asc("created_date")
 	)
 
-	fun delete(id: Long?): Mono<Void> {
+	fun delete(id: Long?): Mono<Unit> {
 		return r2dbcEntityTemplate.delete(EventSourcing::class.java)
 			.from(tableName)
 			.matching(Query.query(Criteria.where("id").`is`(id!!)))
 			.all()
-			.then()
+			.then(Mono.just(Unit))
 	}
 
 	override suspend fun load(id: ID): Flow<EVENT> {

--- a/s2-test/s2-test-bdd/src/main/kotlin/s2/bdd/auth/AuthedUser.kt
+++ b/s2-test/s2-test-bdd/src/main/kotlin/s2/bdd/auth/AuthedUser.kt
@@ -13,7 +13,20 @@ data class AuthedUser(
     override val id: UserId,
     override val memberOf: OrganizationId?,
     override val roles: Array<String>
-): AuthedUserDTO
+): AuthedUserDTO {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is AuthedUser) return false
+        return id == other.id && memberOf == other.memberOf && roles.contentEquals(other.roles)
+    }
+
+    override fun hashCode(): Int {
+        var result = id.hashCode()
+        result = 31 * result + (memberOf?.hashCode() ?: 0)
+        result = 31 * result + roles.contentHashCode()
+        return result
+    }
+}
 
 fun AuthedUserDTO.hasRole(role: String) = role in roles
 fun AuthedUserDTO.hasRole(role: Role) = role.value in roles

--- a/s2-test/s2-test-bdd/src/main/kotlin/s2/bdd/data/TestContext.kt
+++ b/s2-test/s2-test-bdd/src/main/kotlin/s2/bdd/data/TestContext.kt
@@ -24,5 +24,7 @@ open class TestContext {
         authedUser = null
     }
 
-    open fun resetEnv() {}
+    open fun resetEnv() {
+        // No environment state to reset by default, subclasses may override
+    }
 }

--- a/s2-test/s2-test-bdd/src/test/kotlin/s2/bdd/assertion/AssertionApplicationEventsTest.kt
+++ b/s2-test/s2-test-bdd/src/test/kotlin/s2/bdd/assertion/AssertionApplicationEventsTest.kt
@@ -1,0 +1,79 @@
+package s2.bdd.assertion
+
+import f2.dsl.cqrs.Event
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import s2.bdd.data.TestContext
+
+class AssertionApplicationEventsTest {
+
+    private data class OrderPlacedEvent(val orderId: String) : Event
+    private data class OrderCanceledEvent(val orderId: String) : Event
+
+    private fun contextWithEvents(vararg events: Event): TestContext {
+        val context = TestContext()
+        context.events.addAll(events)
+        return context
+    }
+
+    @Test
+    fun `hasBeenSent should pass when count matches`() {
+        val context = contextWithEvents(
+            OrderPlacedEvent("1"),
+            OrderPlacedEvent("2"),
+            OrderCanceledEvent("1")
+        )
+
+        AssertionBdd.events(context)
+            .assertThat(OrderPlacedEvent::class)
+            .hasBeenSent(2)
+    }
+
+    @Test
+    fun `hasBeenSent should fail when count does not match`() {
+        val context = contextWithEvents(OrderPlacedEvent("1"))
+
+        assertThatThrownBy {
+            AssertionBdd.events(context)
+                .assertThat(OrderPlacedEvent::class)
+                .hasBeenSent(2)
+        }.isInstanceOf(AssertionError::class.java)
+    }
+
+    @Test
+    fun `hasNotBeenSent should pass when no matching event`() {
+        val context = contextWithEvents(OrderCanceledEvent("1"))
+
+        AssertionBdd.events(context)
+            .assertThat(OrderPlacedEvent::class)
+            .hasNotBeenSent()
+    }
+
+    @Test
+    fun `hasBeenSentAtLeast and atMost should respect bounds`() {
+        val context = contextWithEvents(
+            OrderPlacedEvent("1"),
+            OrderPlacedEvent("2")
+        )
+        val assertion = AssertionBdd.events(context).assertThat(OrderPlacedEvent::class)
+
+        assertion.hasBeenSentAtLeast(1)
+        assertion.hasBeenSentAtMost(2)
+        assertThatThrownBy { assertion.hasBeenSentAtLeast(3) }
+            .isInstanceOf(AssertionError::class.java)
+        assertThatThrownBy { assertion.hasBeenSentAtMost(1) }
+            .isInstanceOf(AssertionError::class.java)
+    }
+
+    @Test
+    fun `matcher should filter events`() {
+        val context = contextWithEvents(
+            OrderPlacedEvent("match"),
+            OrderPlacedEvent("no-match")
+        )
+
+        AssertionBdd.events(context)
+            .assertThat(OrderPlacedEvent::class)
+            .hasBeenSent(1) { it.orderId == "match" }
+    }
+}

--- a/s2-test/s2-test-bdd/src/test/kotlin/s2/bdd/assertion/AssertionExceptionsTest.kt
+++ b/s2-test/s2-test-bdd/src/test/kotlin/s2/bdd/assertion/AssertionExceptionsTest.kt
@@ -1,0 +1,75 @@
+package s2.bdd.assertion
+
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import s2.bdd.data.TestContext
+
+class AssertionExceptionsTest {
+
+    private fun contextWithErrors(vararg exceptions: Exception): TestContext {
+        val context = TestContext()
+        exceptions.forEach(context.errors::add)
+        return context
+    }
+
+    @Test
+    fun `hasBeenThrown should pass when count matches`() {
+        val context = contextWithErrors(
+            IllegalArgumentException("first"),
+            IllegalArgumentException("second"),
+            IllegalStateException("other")
+        )
+
+        AssertionBdd.exceptions(context)
+            .assertThat(IllegalArgumentException::class)
+            .hasBeenThrown(2)
+    }
+
+    @Test
+    fun `hasBeenThrown should fail when count does not match`() {
+        val context = contextWithErrors(IllegalArgumentException("first"))
+
+        assertThatThrownBy {
+            AssertionBdd.exceptions(context)
+                .assertThat(IllegalArgumentException::class)
+                .hasBeenThrown(2)
+        }.isInstanceOf(AssertionError::class.java)
+    }
+
+    @Test
+    fun `hasNotBeenThrown should pass when no matching exception`() {
+        val context = contextWithErrors(IllegalStateException("other"))
+
+        AssertionBdd.exceptions(context)
+            .assertThat(IllegalArgumentException::class)
+            .hasNotBeenThrown()
+    }
+
+    @Test
+    fun `hasBeenThrownAtLeast and atMost should respect bounds`() {
+        val context = contextWithErrors(
+            IllegalArgumentException("first"),
+            IllegalArgumentException("second")
+        )
+        val assertion = AssertionBdd.exceptions(context).assertThat(IllegalArgumentException::class)
+
+        assertion.hasBeenThrownAtLeast(1)
+        assertion.hasBeenThrownAtMost(2)
+        assertThatThrownBy { assertion.hasBeenThrownAtLeast(3) }
+            .isInstanceOf(AssertionError::class.java)
+        assertThatThrownBy { assertion.hasBeenThrownAtMost(1) }
+            .isInstanceOf(AssertionError::class.java)
+    }
+
+    @Test
+    fun `matcher should filter exceptions`() {
+        val context = contextWithErrors(
+            IllegalArgumentException("match"),
+            IllegalArgumentException("no-match")
+        )
+
+        AssertionBdd.exceptions(context)
+            .assertThat(IllegalArgumentException::class)
+            .hasBeenThrown(1) { it.message == "match" }
+    }
+}

--- a/s2-test/s2-test-bdd/src/test/kotlin/s2/bdd/auth/AuthedUserTest.kt
+++ b/s2-test/s2-test-bdd/src/test/kotlin/s2/bdd/auth/AuthedUserTest.kt
@@ -1,0 +1,55 @@
+package s2.bdd.auth
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class AuthedUserTest {
+
+    private val user = AuthedUser(
+        id = "user-1",
+        memberOf = "org-1",
+        roles = arrayOf("admin", "writer")
+    )
+
+    @Test
+    fun `equals should compare id memberOf and roles content`() {
+        val same = AuthedUser(id = "user-1", memberOf = "org-1", roles = arrayOf("admin", "writer"))
+        val differentRoles = AuthedUser(id = "user-1", memberOf = "org-1", roles = arrayOf("reader"))
+        val differentId = AuthedUser(id = "user-2", memberOf = "org-1", roles = arrayOf("admin", "writer"))
+        val differentOrg = AuthedUser(id = "user-1", memberOf = null, roles = arrayOf("admin", "writer"))
+
+        assertThat(user).isEqualTo(user)
+        assertThat(user).isEqualTo(same)
+        assertThat(user.hashCode()).isEqualTo(same.hashCode())
+        assertThat(user).isNotEqualTo(differentRoles)
+        assertThat(user).isNotEqualTo(differentId)
+        assertThat(user).isNotEqualTo(differentOrg)
+        assertThat(user).isNotEqualTo("not a user")
+    }
+
+    @Test
+    fun `hashCode should handle null memberOf`() {
+        val withoutOrg = AuthedUser(id = "user-1", memberOf = null, roles = arrayOf("admin"))
+        val sameWithoutOrg = AuthedUser(id = "user-1", memberOf = null, roles = arrayOf("admin"))
+
+        assertThat(withoutOrg.hashCode()).isEqualTo(sameWithoutOrg.hashCode())
+    }
+
+    @Test
+    fun `hasRole should check a single role`() {
+        assertThat(user.hasRole("admin")).isTrue()
+        assertThat(user.hasRole("reader")).isFalse()
+    }
+
+    @Test
+    fun `hasRoles should require all roles`() {
+        assertThat(user.hasRoles("admin", "writer")).isTrue()
+        assertThat(user.hasRoles("admin", "reader")).isFalse()
+    }
+
+    @Test
+    fun `hasOneOfRoles should require at least one role`() {
+        assertThat(user.hasOneOfRoles("reader", "writer")).isTrue()
+        assertThat(user.hasOneOfRoles("reader", "auditor")).isFalse()
+    }
+}

--- a/s2-test/s2-test-bdd/src/test/kotlin/s2/bdd/data/ExceptionListTest.kt
+++ b/s2-test/s2-test-bdd/src/test/kotlin/s2/bdd/data/ExceptionListTest.kt
@@ -1,0 +1,60 @@
+package s2.bdd.data
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class ExceptionListTest {
+
+    @Test
+    fun `list should expose added exceptions in order`() {
+        val exceptions = ExceptionList()
+        val first = IllegalArgumentException("first")
+        val second = IllegalStateException("second")
+
+        exceptions.add(first)
+        exceptions.add(second)
+
+        assertThat(exceptions.list).containsExactly(first, second)
+    }
+
+    @Test
+    fun `lastOfType should return the last exception of the given type`() {
+        val exceptions = ExceptionList()
+        val first = IllegalArgumentException("first")
+        val second = IllegalArgumentException("second")
+        exceptions.add(first)
+        exceptions.add(IllegalStateException("other"))
+        exceptions.add(second)
+
+        assertThat(exceptions.lastOfType(IllegalArgumentException::class)).isSameAs(second)
+    }
+
+    @Test
+    fun `lastOfType should return null when no exception of the given type exists`() {
+        val exceptions = ExceptionList()
+        exceptions.add(IllegalStateException("other"))
+
+        assertThat(exceptions.lastOfType(IllegalArgumentException::class)).isNull()
+    }
+
+    @Test
+    fun `filterIsInstance should return only exceptions of the given type`() {
+        val exceptions = ExceptionList()
+        val first = IllegalArgumentException("first")
+        val other = IllegalStateException("other")
+        exceptions.add(first)
+        exceptions.add(other)
+
+        assertThat(exceptions.filterIsInstance(IllegalArgumentException::class)).containsExactly(first)
+    }
+
+    @Test
+    fun `reset should clear all exceptions`() {
+        val exceptions = ExceptionList()
+        exceptions.add(IllegalArgumentException("first"))
+
+        exceptions.reset()
+
+        assertThat(exceptions.list).isEmpty()
+    }
+}

--- a/s2-test/s2-test-bdd/src/test/kotlin/s2/bdd/data/TestContextTest.kt
+++ b/s2-test/s2-test-bdd/src/test/kotlin/s2/bdd/data/TestContextTest.kt
@@ -1,0 +1,38 @@
+package s2.bdd.data
+
+import f2.dsl.cqrs.Event
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import s2.bdd.auth.AuthedUser
+
+class TestContextTest {
+
+    private data class SomeEvent(val id: String) : Event
+
+    @Test
+    fun `testEntities should create and register a named entity list`() {
+        val context = TestContext()
+
+        val entities = context.testEntities<String, String>("order")
+
+        assertThat(context.entityLists).containsEntry("order", entities)
+    }
+
+    @Test
+    fun `reset should clear entities errors events and authed user`() {
+        val context = TestContext()
+        val entities = context.testEntities<String, String>("order")
+        entities["a"] = "entityA"
+        context.errors.add(IllegalStateException("boom"))
+        context.events.add(SomeEvent("evt"))
+        context.authedUser = AuthedUser(id = "user", memberOf = "org", roles = arrayOf("admin"))
+
+        context.reset()
+
+        assertThat(entities.items).isEmpty()
+        assertThat(context.entityLists).containsKey("order")
+        assertThat(context.errors.list).isEmpty()
+        assertThat(context.events).isEmpty()
+        assertThat(context.authedUser).isNull()
+    }
+}

--- a/s2-test/s2-test-bdd/src/test/kotlin/s2/bdd/data/TestEntitiesTest.kt
+++ b/s2-test/s2-test-bdd/src/test/kotlin/s2/bdd/data/TestEntitiesTest.kt
@@ -1,0 +1,99 @@
+package s2.bdd.data
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import s2.bdd.exception.EntityNotInitializedException
+
+class TestEntitiesTest {
+
+    @Test
+    fun `set and get should track the last used entity`() {
+        val entities = TestEntities<String, String>("order")
+        entities["a"] = "entityA"
+
+        assertThat(entities["a"]).isEqualTo("entityA")
+        assertThat(entities.lastUsedKey).isEqualTo("a")
+        assertThat(entities.lastUsed).isEqualTo("entityA")
+        assertThat(entities.lastUsedOrNull).isEqualTo("entityA")
+    }
+
+    @Test
+    fun `lastUsedKey should throw when nothing was used`() {
+        val entities = TestEntities<String, String>("order")
+
+        assertThatThrownBy { entities.lastUsedKey }
+            .isInstanceOf(EntityNotInitializedException::class.java)
+            .hasMessageContaining("order")
+    }
+
+    @Test
+    fun `lastUsed should throw when last used entity is null`() {
+        val entities = TestEntities<String, String>("order")
+        entities["a"] = null
+
+        assertThat(entities.lastUsedOrNull).isNull()
+        assertThatThrownBy { entities.lastUsed }
+            .isInstanceOf(EntityNotInitializedException::class.java)
+    }
+
+    @Test
+    fun `safeGet should return entity or throw when absent`() {
+        val entities = TestEntities<String, String>("order")
+        entities["a"] = "entityA"
+
+        assertThat(entities.safeGet("a")).isEqualTo("entityA")
+        assertThatThrownBy { entities.safeGet("missing") }
+            .isInstanceOf(EntityNotInitializedException::class.java)
+            .hasMessageContaining("missing")
+    }
+
+    @Test
+    fun `items and keys should reflect non-null entities`() {
+        val entities = TestEntities<String, String>("order")
+        entities["a"] = "entityA"
+        entities["b"] = null
+
+        assertThat(entities.items).containsExactly("entityA")
+        assertThat(entities.keys).containsExactlyInAnyOrder("a", "b")
+        assertThat(entities.size).isEqualTo(1)
+        assertThat(entities.containsKey("b")).isTrue()
+        assertThat(entities.containsKey("c")).isFalse()
+    }
+
+    @Test
+    fun `register should store item and rethrow with null value on failure`() {
+        val entities = TestEntities<String, String>("order")
+        entities.register("a") { "entityA" }
+        assertThat(entities["a"]).isEqualTo("entityA")
+
+        assertThatThrownBy {
+            entities.register("b") { error("creation failed") }
+        }.isInstanceOf(IllegalStateException::class.java)
+        assertThat(entities.containsKey("b")).isTrue()
+        assertThat(entities["b"]).isNull()
+    }
+
+    @Test
+    fun `putAll should store all entries from pairs and map`() {
+        val entities = TestEntities<String, String>("order")
+        entities.putAll("a" to "entityA", "b" to "entityB")
+        entities.putAll(mapOf("c" to "entityC"))
+
+        assertThat(entities.keys).containsExactlyInAnyOrder("a", "b", "c")
+        assertThat(entities.map { it.key }).containsExactlyInAnyOrder("a", "b", "c")
+    }
+
+    @Test
+    fun `reset should clear entities and last used`() {
+        val entities = TestEntities<String, String>("order")
+        entities["a"] = "entityA"
+
+        entities.reset()
+
+        assertThat(entities.items).isEmpty()
+        assertThat(entities.lastUsedOrNull).isNull()
+        assertThatThrownBy { entities.lastUsedKey }
+            .isInstanceOf(EntityNotInitializedException::class.java)
+    }
+}

--- a/s2-test/s2-test-bdd/src/test/kotlin/s2/bdd/data/TestEntityIdsTest.kt
+++ b/s2-test/s2-test-bdd/src/test/kotlin/s2/bdd/data/TestEntityIdsTest.kt
@@ -1,0 +1,35 @@
+package s2.bdd.data
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class TestEntityIdsTest {
+
+    @Test
+    fun `plusAssign should add id and track last created`() {
+        val ids = TestEntityIds<String>()
+        ids += "a"
+        ids += "b"
+
+        assertThat(ids.ids).containsExactlyInAnyOrder("a", "b")
+        assertThat(ids.lastCreated).isEqualTo("b")
+        assertThat("a" in ids).isTrue()
+        assertThat("c" in ids).isFalse()
+    }
+
+    @Test
+    fun `add and addAll should register ids`() {
+        val ids = TestEntityIds<Int>()
+        ids.add(1)
+        ids.addAll(listOf(2, 3))
+
+        assertThat(ids.ids).containsExactlyInAnyOrder(1, 2, 3)
+        assertThat(ids.lastCreated).isEqualTo(3)
+    }
+
+    @Test
+    fun `lastCreated should be null when empty`() {
+        assertThat(TestEntityIds<String>().lastCreated).isNull()
+        assertThat(TestEntityIds<String>().ids).isEmpty()
+    }
+}

--- a/s2-test/s2-test-bdd/src/test/kotlin/s2/bdd/data/parser/EntryParserTest.kt
+++ b/s2-test/s2-test-bdd/src/test/kotlin/s2/bdd/data/parser/EntryParserTest.kt
@@ -1,0 +1,102 @@
+package s2.bdd.data.parser
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import s2.bdd.exception.IllegalDataTableParamException
+import s2.bdd.exception.NoParserFoundException
+import s2.bdd.exception.NullDataTableParamException
+
+class EntryParserTest {
+
+    companion object {
+        init {
+            registerPrimitiveParsers()
+        }
+    }
+
+    private val intParser = EntryParserDirectory.select(Int::class)
+
+    @Test
+    fun `singleOrNull should return parsed value when key is present`() {
+        assertThat(intParser.singleOrNull(mapOf("age" to "42"), "age")).isEqualTo(42)
+    }
+
+    @Test
+    fun `singleOrNull should return null when key is absent`() {
+        assertThat(intParser.singleOrNull(emptyMap(), "age")).isNull()
+    }
+
+    @Test
+    fun `singleOrNull should throw IllegalDataTableParamException on unparseable value`() {
+        assertThatThrownBy { intParser.singleOrNull(mapOf("age" to "abc"), "age") }
+            .isInstanceOf(IllegalDataTableParamException::class.java)
+            .hasMessageContaining("age")
+            .hasMessageContaining("Expected Int value")
+    }
+
+    @Test
+    fun `single should return parsed value when key is present`() {
+        assertThat(intParser.single(mapOf("age" to "7"), "age")).isEqualTo(7)
+    }
+
+    @Test
+    fun `single should throw NullDataTableParamException when key is absent`() {
+        assertThatThrownBy { intParser.single(emptyMap(), "age") }
+            .isInstanceOf(NullDataTableParamException::class.java)
+            .hasMessageContaining("age")
+    }
+
+    @Test
+    fun `listOrNull should split and trim comma-separated values`() {
+        assertThat(intParser.listOrNull(mapOf("ids" to "1, 2 ,3"), "ids"))
+            .containsExactly(1, 2, 3)
+    }
+
+    @Test
+    fun `listOrNull should return null when key is absent`() {
+        assertThat(intParser.listOrNull(emptyMap(), "ids")).isNull()
+    }
+
+    @Test
+    fun `listOrNull should throw IllegalDataTableParamException on unparseable element`() {
+        assertThatThrownBy { intParser.listOrNull(mapOf("ids" to "1,x"), "ids") }
+            .isInstanceOf(IllegalDataTableParamException::class.java)
+    }
+
+    @Test
+    fun `list should return parsed values`() {
+        assertThat(intParser.list(mapOf("ids" to "5,6"), "ids")).containsExactly(5, 6)
+    }
+
+    @Test
+    fun `list should throw NullDataTableParamException when key is absent`() {
+        assertThatThrownBy { intParser.list(emptyMap(), "ids") }
+            .isInstanceOf(NullDataTableParamException::class.java)
+    }
+
+    @Test
+    fun `directory select should throw NoParserFoundException for unregistered type`() {
+        class Unregistered
+        assertThatThrownBy { EntryParserDirectory.select(Unregistered::class) }
+            .isInstanceOf(NoParserFoundException::class.java)
+            .hasMessageContaining("Unregistered")
+    }
+
+    @Test
+    fun `directory register should allow selecting the registered parser`() {
+        data class Custom(val raw: String)
+        val parser = EntryParser(Custom::class, "invalid custom") { Custom(it) }
+        assertThat(EntryParserDirectory.select(Custom::class)).isSameAs(parser)
+        assertThat(parser.single(mapOf("c" to "v"), "c")).isEqualTo(Custom("v"))
+    }
+}
+
+internal fun registerPrimitiveParsers() {
+    StringParser()
+    IntParser()
+    LongParser()
+    FloatParser()
+    DoubleParser()
+    BooleanParser()
+}

--- a/s2-test/s2-test-bdd/src/test/kotlin/s2/bdd/data/parser/GenericParserTest.kt
+++ b/s2-test/s2-test-bdd/src/test/kotlin/s2/bdd/data/parser/GenericParserTest.kt
@@ -1,0 +1,55 @@
+@file:Suppress("DEPRECATION")
+
+package s2.bdd.data.parser
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import s2.bdd.exception.IllegalDataTableParamException
+import s2.bdd.exception.NullDataTableParamException
+
+class GenericParserTest {
+
+    companion object {
+        init {
+            registerPrimitiveParsers()
+        }
+    }
+
+    private val entry = mapOf("count" to "3", "ids" to "1,2", "raw" to "abc")
+
+    @Test
+    fun `deprecated extract should parse value with provided parser`() {
+        assertThat(entry.extract<Int>("count", "Expected Int") { it.toIntOrNull() }).isEqualTo(3)
+        assertThat(entry.extract<Int>("missing", "Expected Int") { it.toIntOrNull() }).isNull()
+    }
+
+    @Test
+    fun `deprecated extract should throw on unparseable value`() {
+        assertThatThrownBy { entry.extract<Int>("raw", "Expected Int") { it.toIntOrNull() } }
+            .isInstanceOf(IllegalDataTableParamException::class.java)
+            .hasMessageContaining("Expected Int")
+    }
+
+    @Test
+    fun `deprecated safeExtract should throw when key is absent`() {
+        assertThat(entry.safeExtract<Int>("count", "Expected Int") { it.toIntOrNull() }).isEqualTo(3)
+        assertThatThrownBy { entry.safeExtract<Int>("missing", "Expected Int") { it.toIntOrNull() } }
+            .isInstanceOf(NullDataTableParamException::class.java)
+    }
+
+    @Test
+    fun `deprecated extractList should parse each element`() {
+        assertThat(entry.extractList<Int>("ids", "Expected Int") { it.toIntOrNull() })
+            .containsExactly(1, 2)
+        assertThat(entry.extractList<Int>("missing", "Expected Int") { it.toIntOrNull() }).isNull()
+    }
+
+    @Test
+    fun `deprecated safeExtractList should throw when key is absent`() {
+        assertThat(entry.safeExtractList<Int>("ids", "Expected Int") { it.toIntOrNull() })
+            .containsExactly(1, 2)
+        assertThatThrownBy { entry.safeExtractList<Int>("missing", "Expected Int") { it.toIntOrNull() } }
+            .isInstanceOf(NullDataTableParamException::class.java)
+    }
+}

--- a/s2-test/s2-test-bdd/src/test/kotlin/s2/bdd/data/parser/ParserExtensionTest.kt
+++ b/s2-test/s2-test-bdd/src/test/kotlin/s2/bdd/data/parser/ParserExtensionTest.kt
@@ -1,0 +1,43 @@
+package s2.bdd.data.parser
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import s2.bdd.exception.NullDataTableParamException
+
+class ParserExtensionTest {
+
+    companion object {
+        init {
+            registerPrimitiveParsers()
+        }
+    }
+
+    private val entry = mapOf("count" to "3", "ids" to "1,2,3")
+
+    @Test
+    fun `extract should return parsed value or null`() {
+        assertThat(entry.extract<Int>("count")).isEqualTo(3)
+        assertThat(entry.extract<Int>("missing")).isNull()
+    }
+
+    @Test
+    fun `safeExtract should return parsed value or throw`() {
+        assertThat(entry.safeExtract<Int>("count")).isEqualTo(3)
+        assertThatThrownBy { entry.safeExtract<Int>("missing") }
+            .isInstanceOf(NullDataTableParamException::class.java)
+    }
+
+    @Test
+    fun `extractList should return parsed list or null`() {
+        assertThat(entry.extractList<Int>("ids")).containsExactly(1, 2, 3)
+        assertThat(entry.extractList<Int>("missing")).isNull()
+    }
+
+    @Test
+    fun `safeExtractList should return parsed list or throw`() {
+        assertThat(entry.safeExtractList<Int>("ids")).containsExactly(1, 2, 3)
+        assertThatThrownBy { entry.safeExtractList<Int>("missing") }
+            .isInstanceOf(NullDataTableParamException::class.java)
+    }
+}

--- a/s2-test/s2-test-bdd/src/test/kotlin/s2/bdd/data/parser/PrimitiveParsersTest.kt
+++ b/s2-test/s2-test-bdd/src/test/kotlin/s2/bdd/data/parser/PrimitiveParsersTest.kt
@@ -1,0 +1,64 @@
+package s2.bdd.data.parser
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import s2.bdd.exception.IllegalDataTableParamException
+
+class PrimitiveParsersTest {
+
+    companion object {
+        init {
+            registerPrimitiveParsers()
+        }
+    }
+
+    private val entry = mapOf(
+        "name" to "alice",
+        "int" to "42",
+        "long" to "9000000000",
+        "float" to "1.5",
+        "double" to "2.25",
+        "bool" to "true"
+    )
+
+    @Test
+    fun `string parser should return raw value`() {
+        assertThat(entry.extract<String>("name")).isEqualTo("alice")
+    }
+
+    @Test
+    fun `int parser should parse valid value and reject invalid`() {
+        assertThat(entry.extract<Int>("int")).isEqualTo(42)
+        assertThatThrownBy { entry.extract<Int>("name") }
+            .isInstanceOf(IllegalDataTableParamException::class.java)
+    }
+
+    @Test
+    fun `long parser should parse valid value and reject invalid`() {
+        assertThat(entry.extract<Long>("long")).isEqualTo(9_000_000_000L)
+        assertThatThrownBy { entry.extract<Long>("name") }
+            .isInstanceOf(IllegalDataTableParamException::class.java)
+    }
+
+    @Test
+    fun `float parser should parse valid value and reject invalid`() {
+        assertThat(entry.extract<Float>("float")).isEqualTo(1.5f)
+        assertThatThrownBy { entry.extract<Float>("name") }
+            .isInstanceOf(IllegalDataTableParamException::class.java)
+    }
+
+    @Test
+    fun `double parser should parse valid value and reject invalid`() {
+        assertThat(entry.extract<Double>("double")).isEqualTo(2.25)
+        assertThatThrownBy { entry.extract<Double>("name") }
+            .isInstanceOf(IllegalDataTableParamException::class.java)
+    }
+
+    @Test
+    fun `boolean parser should parse strict boolean and reject invalid`() {
+        assertThat(entry.extract<Boolean>("bool")).isTrue()
+        assertThatThrownBy { entry.extract<Boolean>("name") }
+            .isInstanceOf(IllegalDataTableParamException::class.java)
+    }
+}


### PR DESCRIPTION
Resolves open SonarQube issues:

- **S1186**: add explanatory comment to empty `TestContext.resetEnv()` (open method meant for override)
- **S6218**: explicit `equals`/`hashCode` for `AuthedUser` data class with `Array` property (contentEquals/contentHashCode)
- **S6508**: `R2dbcEventRepository.delete` returns `Mono<Unit>` instead of `Mono<Void>` (no callers in repo)

Verified: targeted `compileKotlin` + detekt green on affected modules.

Skipped (out of scope): INFO-level S1133 deprecated-code reminders and S1135 TODO.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved event deletion completion reporting so successful deletions return an explicit completion value.
  * Fixed authenticated-user comparisons to consistently account for role contents.

* **Maintenance**
  * Clarified that test environment reset behavior can be customized by subclasses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->