### PR TITLE
refactor: use suspend test functions instead of runBlocking/runTest

### DIFF
--- a/s2-automate/s2-automate-core/src/jvmTest/kotlin/s2/automate/core/snap/RetryTaskChannelTest.kt
+++ b/s2-automate/s2-automate-core/src/jvmTest/kotlin/s2/automate/core/snap/RetryTaskChannelTest.kt
@@ -1,7 +1,6 @@
 package s2.automate.core.snap
 
 import java.util.concurrent.atomic.AtomicInteger
-import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -21,7 +20,7 @@ class RetryTaskChannelTest {
     }
 
     @Test
-    fun `test add to persist queue`() = runTest {
+    suspend fun `test add to persist queue`() {
         val id = "testId"
         val event = "testEvent"
         val result: Pair<String, String> = retryTaskChannel.addToPersistQueue(id, event) { evt ->
@@ -32,7 +31,7 @@ class RetryTaskChannelTest {
     }
 
     @Test
-    fun `test retry on RetryException failure`() = runTest {
+    suspend fun `test retry on RetryException failure`() {
         val id = "testId"
         val event = "testEvent"
         val attempts = AtomicInteger(0)
@@ -50,7 +49,7 @@ class RetryTaskChannelTest {
     }
 
     @Test
-    fun `test max retry RetryException attempts`() = runTest {
+    suspend fun `test max retry RetryException attempts`() {
         val id = "testId"
         val event = "testEvent"
         val attempts = AtomicInteger(0)
@@ -67,7 +66,7 @@ class RetryTaskChannelTest {
     }
 
     @Test
-    fun `test no retry on non-RetryException failure`() = runTest {
+    suspend fun `test no retry on non-RetryException failure`() {
         val id = "testId"
         val event = "testEvent"
         val attempts = AtomicInteger(0)

--- a/s2-event-sourcing/s2-event-sourcing-dsl/src/jvmTest/kotlin/s2/sourcing/dsl/view/ViewLoaderTest.kt
+++ b/s2-event-sourcing/s2-event-sourcing-dsl/src/jvmTest/kotlin/s2/sourcing/dsl/view/ViewLoaderTest.kt
@@ -2,7 +2,6 @@ package s2.sourcing.dsl.view
 
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import s2.dsl.automate.Evt
@@ -12,7 +11,7 @@ import s2.sourcing.dsl.event.EventRepository
 class ViewLoaderTest {
 
     @Test
-    fun testReloadHistoryWithComparableElement() = runTest {
+    suspend fun testReloadHistoryWithComparableElement() {
         // Given
         val eventRepository = TestEventRepository()
         val view = TestView()
@@ -28,7 +27,7 @@ class ViewLoaderTest {
     }
 
     @Test
-    fun testReloadHistoryWithNonComparableElement() = runTest {
+    suspend fun testReloadHistoryWithNonComparableElement() {
         // Given
         val eventRepository = TestEventNonComparableRepository()
         val view = TestNonComparableView()

--- a/s2-spring/sourcing/s2-spring-boot-starter-sourcing-data-r2dbc/src/test/kotlin/s2/spring/sourcing/data/r2dbc/R2dbcEventRepositoryTest.kt
+++ b/s2-spring/sourcing/s2-spring-boot-starter-sourcing-data-r2dbc/src/test/kotlin/s2/spring/sourcing/data/r2dbc/R2dbcEventRepositoryTest.kt
@@ -3,7 +3,6 @@ package s2.spring.sourcing.data.r2dbc
 import java.util.UUID
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.toList
-import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import org.assertj.core.api.Assertions.assertThat
@@ -38,7 +37,7 @@ class R2dbcEventRepositoryTest : SpringTestBase() {
     private val json = Json { ignoreUnknownKeys = true }
 
     @BeforeEach
-    fun setup() = runBlocking {
+    suspend fun setup() {
         eventRepository = R2dbcEventRepository(
             json = json,
             databaseClient = databaseClient,
@@ -51,7 +50,7 @@ class R2dbcEventRepositoryTest : SpringTestBase() {
     }
 
     @Test
-    fun `should load events in ascending order by created_date`(): Unit = runBlocking {
+    suspend fun `should load events in ascending order by created_date`() {
         // Given
         val objId = UUID.randomUUID().toString()
 
@@ -80,7 +79,7 @@ class R2dbcEventRepositoryTest : SpringTestBase() {
     }
 
     @Test
-    fun `should load all events in ascending order by created_date`(): Unit = runBlocking {
+    suspend fun `should load all events in ascending order by created_date`() {
         // Given
         val objId1 = UUID.randomUUID().toString()
         val objId2 = UUID.randomUUID().toString()

--- a/s2-spring/storing/s2-spring-boot-starter-storing/src/test/kotlin/s2/spring/automate/executor/S2AutomateExecutorSpringPassthroughTest.kt
+++ b/s2-spring/storing/s2-spring-boot-starter-storing/src/test/kotlin/s2/spring/automate/executor/S2AutomateExecutorSpringPassthroughTest.kt
@@ -5,7 +5,6 @@ import f2.dsl.cqrs.enveloped.EnvelopedFlow
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.toList
-import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import s2.automate.core.appevent.listener.AutomateListenerAdapter
@@ -137,7 +136,7 @@ class S2AutomateExecutorSpringPassthroughTest {
     // ---- tests ----
 
     @Test
-    fun `evolveWithOutcomes (init) delegates to engine evolveWithOutcomes (init)`() = runTest {
+    suspend fun `evolveWithOutcomes (init) delegates to engine evolveWithOutcomes (init)`() {
         val executor = makeExecutor()
 
         val returned: Flow<PersistOutcome<TestEvt>> = executor.evolveWithOutcomes(
@@ -151,7 +150,7 @@ class S2AutomateExecutorSpringPassthroughTest {
     }
 
     @Test
-    fun `evolveWithOutcomes (transition) delegates to engine evolveWithOutcomes (transition)`() = runTest {
+    suspend fun `evolveWithOutcomes (transition) delegates to engine evolveWithOutcomes (transition)`() {
         val executor = makeExecutor()
 
         val returned: Flow<PersistOutcome<TestEvt>> = executor.evolveWithOutcomes(

--- a/sample/orderbook-sourcing/orderbook-sourcing-app-mongodb/src/test/kotlin/s2/sample/orderbook/sourcing/app/mongodb/SubAutomateMongodbAppTest.kt
+++ b/sample/orderbook-sourcing/orderbook-sourcing-app-mongodb/src/test/kotlin/s2/sample/orderbook/sourcing/app/mongodb/SubAutomateMongodbAppTest.kt
@@ -2,7 +2,6 @@ package s2.sample.orderbook.sourcing.app.mongodb
 
 import f2.dsl.fnc.invoke
 import kotlinx.coroutines.flow.toList
-import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -47,7 +46,7 @@ internal class SubAutomateMongodbAppTest: SpringTestBase() {
 	lateinit var orderBookDeciderImpl: OrderBookDeciderImpl
 
 	@Test
-	fun `should create order book`(): Unit = runBlocking {
+	suspend fun `should create order book`() {
 		val event = orderBookDeciderImpl.orderBookCreateDecider().invoke(OrderBookCreateCommand("TheNewOrderBook"))
 		orderBookDeciderImpl.orderBookUpdateDecider().invoke(OrderBookUpdateCommand(id = event.id, name = "TheNewOrderBook2"))
 		orderBookDeciderImpl.orderBookPublishDecider().invoke(OrderBookPublishCommand(id = event.id))
@@ -57,7 +56,7 @@ internal class SubAutomateMongodbAppTest: SpringTestBase() {
 	}
 
 	@Test
-	fun `should replay event to build entity`(): Unit = runBlocking {
+	suspend fun `should replay event to build entity`() {
 		val event = create(OrderBookCreateCommand("TheNewOrderBook"))
 		update(OrderBookUpdateCommand(id = event.id, name = "TheNewOrderBook2"))
 		publish(OrderBookPublishCommand(id = event.id))
@@ -69,7 +68,7 @@ internal class SubAutomateMongodbAppTest: SpringTestBase() {
 	}
 
 	@Test
-	fun `should replay all events to rebuild entities`(): Unit = runBlocking {
+	suspend fun `should replay all events to rebuild entities`() {
 		val event = create(OrderBookCreateCommand("TheNewOrderBook"))
 		update(OrderBookUpdateCommand(id = event.id, name = "TheNewOrderBook2"))
 		publish(OrderBookPublishCommand(id = event.id))

--- a/sample/orderbook-sourcing/orderbook-sourcing-app-r2dbc/src/test/kotlin/s2/sample/orderbook/sourcing/app/r2dbc/SubAutomateR2dbcAppTest.kt
+++ b/sample/orderbook-sourcing/orderbook-sourcing-app-r2dbc/src/test/kotlin/s2/sample/orderbook/sourcing/app/r2dbc/SubAutomateR2dbcAppTest.kt
@@ -2,7 +2,6 @@ package s2.sample.orderbook.sourcing.app.r2dbc
 
 import f2.dsl.fnc.invoke
 import kotlinx.coroutines.flow.toList
-import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -47,7 +46,7 @@ internal class SubAutomateR2dbcAppTest: SpringTestBase() {
 	lateinit var orderBookDeciderImpl: OrderBookDeciderImpl
 
 	@Test
-	fun `should create order book`(): Unit = runBlocking {
+	suspend fun `should create order book`() {
 		val event = orderBookDeciderImpl.orderBookCreateDecider().invoke(OrderBookCreateCommand("TheNewOrderBook"))
 		orderBookDeciderImpl.orderBookUpdateDecider().invoke(OrderBookUpdateCommand(id = event.id, name = "TheNewOrderBook2"))
 		orderBookDeciderImpl.orderBookPublishDecider().invoke(OrderBookPublishCommand(id = event.id))
@@ -57,7 +56,7 @@ internal class SubAutomateR2dbcAppTest: SpringTestBase() {
 	}
 
 	@Test
-	fun `should replay event to build entity`(): Unit = runBlocking {
+	suspend fun `should replay event to build entity`() {
 		val event = create(OrderBookCreateCommand("TheNewOrderBook"))
 		update(OrderBookUpdateCommand(id = event.id, name = "TheNewOrderBook2"))
 		publish(OrderBookPublishCommand(id = event.id))
@@ -69,7 +68,7 @@ internal class SubAutomateR2dbcAppTest: SpringTestBase() {
 	}
 
 	@Test
-	fun `should replay all events to rebuild entities`(): Unit = runBlocking {
+	suspend fun `should replay all events to rebuild entities`() {
 		val event = create(OrderBookCreateCommand("TheNewOrderBook"))
 		update(OrderBookUpdateCommand(id = event.id, name = "TheNewOrderBook2"))
 		publish(OrderBookPublishCommand(id = event.id))

--- a/sample/orderbook-sourcing/orderbook-sourcing-core/src/test/kotlin/s2/sample/orderbook/sourcing/core/redis/RedisSnapViewIntegrationTest.kt
+++ b/sample/orderbook-sourcing/orderbook-sourcing-core/src/test/kotlin/s2/sample/orderbook/sourcing/core/redis/RedisSnapViewIntegrationTest.kt
@@ -6,7 +6,6 @@ import io.lettuce.core.api.StatefulRedisConnection
 import io.lettuce.core.protocol.ProtocolVersion
 import io.lettuce.core.support.ConnectionPoolSupport
 import kotlinx.coroutines.flow.toList
-import kotlinx.coroutines.runBlocking
 import org.apache.commons.pool2.impl.GenericObjectPool
 import org.apache.commons.pool2.impl.GenericObjectPoolConfig
 import org.junit.jupiter.api.AfterAll
@@ -77,7 +76,7 @@ class RedisSnapViewIntegrationTest {
 	inner class CrudOperations {
 		@Test
 		@Order(1)
-		fun `should save and get entity`() = runBlocking {
+		suspend fun `should save and get entity`() {
 			val entity = TestEntity(id = "1", name = "Test", status = "active")
 			val saved = redisSnapView.save<TestEntity>("1", entity)
 
@@ -92,14 +91,14 @@ class RedisSnapViewIntegrationTest {
 
 		@Test
 		@Order(2)
-		fun `should return null for non-existent entity`() = runBlocking {
+		suspend fun `should return null for non-existent entity`() {
 			val result = redisSnapView.get<TestEntity>("non-existent")
 			assertNull(result)
 		}
 
 		@Test
 		@Order(3)
-		fun `should update existing entity`() = runBlocking {
+		suspend fun `should update existing entity`() {
 			val entity = TestEntity(id = "2", name = "Original", status = "draft")
 			redisSnapView.save<TestEntity>("2", entity)
 
@@ -114,7 +113,7 @@ class RedisSnapViewIntegrationTest {
 
 		@Test
 		@Order(4)
-		fun `should delete entity`() = runBlocking {
+		suspend fun `should delete entity`() {
 			val entity = TestEntity(id = "to-delete", name = "Delete Me", status = "active")
 			redisSnapView.save<TestEntity>("to-delete", entity)
 
@@ -131,7 +130,7 @@ class RedisSnapViewIntegrationTest {
 	inner class IndexAndSearch {
 		@Test
 		@Order(1)
-		fun `should create index and search entities`() = runBlocking {
+		suspend fun `should create index and search entities`() {
 			redisSnapView.dropIndex<TestEntity>()
 			redisSnapView.createIndex<TestEntity>(
 				RedisIndexField("name", RedisFieldType.TEXT),
@@ -151,35 +150,35 @@ class RedisSnapViewIntegrationTest {
 
 		@Test
 		@Order(2)
-		fun `should search by tag`() = runBlocking {
+		suspend fun `should search by tag`() {
 			val result = redisSnapView.searchById<TestEntity>("status", "active")
 			assertTrue(result.total >= 2, "Expected at least 2 active results, got ${result.total}")
 		}
 
 		@Test
 		@Order(3)
-		fun `should count entities`() = runBlocking {
+		suspend fun `should count entities`() {
 			val count = redisSnapView.count<TestEntity>()
 			assertTrue(count >= 3, "Expected at least 3, got $count")
 		}
 
 		@Test
 		@Order(4)
-		fun `should get all entities`() = runBlocking {
+		suspend fun `should get all entities`() {
 			val all = redisSnapView.all<TestEntity>().toList()
 			assertTrue(all.size >= 3, "Expected at least 3, got ${all.size}")
 		}
 
 		@Test
 		@Order(5)
-		fun `should drop index without error`() = runBlocking {
+		suspend fun `should drop index without error`() {
 			redisSnapView.dropIndex<TestEntity>()
 			// Should not throw — verifies dropIndex works
 		}
 
 		@Test
 		@Order(6)
-		fun `should handle drop of non-existent index`() = runBlocking {
+		suspend fun `should handle drop of non-existent index`() {
 			// Drop again on already-dropped index — should handle gracefully
 			redisSnapView.dropIndex<TestEntity>()
 		}


### PR DESCRIPTION
Converts JUnit test methods to `@Test suspend fun` (native JUnit Jupiter 6 support), replacing `runBlocking`/`runTest` wrappers — 7 files, 26 tests plus one suspend `@BeforeEach` (runtime-verified).

Kept as-is:
- `s2-automate-core` commonTest files: KMP common tests also compile to JS, and kotlin-test common has no suspend `@Test` support — `runTest` is required there
- Cucumber step definitions (Cucumber cannot invoke suspend functions)

All converted tests were run green locally, including the infra-dependent ones (Redis/MongoDB/R2DBC via testcontainers); detekt clean.

Follow-up of #91.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated coroutine-based tests to run directly as suspend functions.
  * Removed unnecessary blocking wrappers while preserving existing assertions and test behavior.
  * Improved consistency across channel, event-sourcing, database, application, and Redis integration tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->