### PR TITLE
ci: run SonarCloud analysis via the libs check step

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -34,5 +34,8 @@ jobs:
     permissions:
       contents: write
       pull-requests: read
+    with:
+      # SonarCloud analysis runs via the Gradle sonar task in the libs check step.
+      with-sonarcloud: false
     secrets:
       FIXERS_SONAR_TOKEN: ${{ secrets.FIXERS_SONAR_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 VERSION = $(shell cat VERSION)
 
-.PHONY: clean lint build test publish promote
+.PHONY: clean lint build test check publish promote
 
 clean:
 	@make -f infra/make/libs.mk clean
@@ -13,6 +13,9 @@ build:
 
 test:
 	@make -f infra/make/libs.mk test
+
+check:
+	@make -f infra/make/libs.mk check
 
 stage:
 	@make -f infra/make/libs.mk stage

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -34,6 +34,10 @@ jackson-module-kotlin = { group = "tools.jackson.module", name = "jackson-module
 kotlinx-serialization-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-core" }
 kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json" }
 
+# Coroutines (versions from BOM)
+kotlinx-coroutines-reactive = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-reactive" }
+kotlinx-coroutines-reactor = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-reactor" }
+
 # Logging (versions from BOM)
 slf4j-api = { group = "org.slf4j", name = "slf4j-api" }
 

--- a/infra/make/libs.mk
+++ b/infra/make/libs.mk
@@ -1,6 +1,6 @@
 VERSION = $(shell cat VERSION)
 
-.PHONY: clean lint build test publish promote version
+.PHONY: clean lint build test check publish promote version
 
 clean:
 	./gradlew clean
@@ -13,6 +13,9 @@ build:
 
 test:
 	./gradlew test
+
+check:
+	VERSION=$(VERSION) ./gradlew sonar
 
 stage:
 	VERSION=$(VERSION) ./gradlew stage

--- a/s2-automate/s2-automate-core/build.gradle.kts
+++ b/s2-automate/s2-automate-core/build.gradle.kts
@@ -8,6 +8,8 @@ dependencies {
 	commonMainApi(project(":s2-event-sourcing:s2-event-sourcing-dsl"))
 
 	commonTestImplementation(kotlin("test"))
+	commonTestImplementation(libs.kotlinx.coroutines.test)
 	"jvmTestImplementation"(kotlin("test-junit5"))
+	"jvmTestImplementation"(libs.bundles.test.junit)
 	"jsTestImplementation"(kotlin("test-js"))
 }

--- a/s2-automate/s2-automate-dsl/build.gradle.kts
+++ b/s2-automate/s2-automate-dsl/build.gradle.kts
@@ -6,4 +6,6 @@ plugins {
 
 dependencies {
 	commonMainApi(libs.f2.dsl.cqrs)
+
+	"jvmTestImplementation"(libs.bundles.test.junit)
 }

--- a/s2-event-sourcing/s2-event-sourcing-dsl/build.gradle.kts
+++ b/s2-event-sourcing/s2-event-sourcing-dsl/build.gradle.kts
@@ -6,4 +6,6 @@ plugins {
 dependencies {
 	commonMainApi(project(":s2-automate:s2-automate-dsl"))
 	commonMainApi(libs.f2.dsl.function)
+
+	"jvmTestImplementation"(libs.bundles.test.junit)
 }

--- a/s2-spring/sourcing/s2-spring-boot-starter-sourcing-data-r2dbc/build.gradle.kts
+++ b/s2-spring/sourcing/s2-spring-boot-starter-sourcing-data-r2dbc/build.gradle.kts
@@ -8,6 +8,8 @@ dependencies {
 	api(project(":s2-spring:sourcing:s2-spring-boot-starter-sourcing-data"))
 	api(libs.spring.boot.starter.data.r2dbc)
 	implementation(libs.kotlinx.serialization.json)
+	implementation(libs.kotlinx.coroutines.reactive)
+	implementation(libs.kotlinx.coroutines.reactor)
 
 	// Test dependencies
 	testImplementation(libs.bundles.testcontainers)

--- a/s2-spring/storing/s2-spring-boot-starter-storing-data/build.gradle.kts
+++ b/s2-spring/storing/s2-spring-boot-starter-storing-data/build.gradle.kts
@@ -9,4 +9,6 @@ dependencies {
 	api(project(":s2-spring:storing:s2-spring-boot-starter-storing"))
 	api(project(":s2-spring:utils:s2-spring-boot-starter-utils-data"))
 	implementation(libs.bundles.spring.data.commons)
+	implementation(libs.kotlinx.coroutines.reactive)
+	implementation(libs.kotlinx.coroutines.reactor)
 }

--- a/s2-spring/storing/s2-spring-boot-starter-storing/build.gradle.kts
+++ b/s2-spring/storing/s2-spring-boot-starter-storing/build.gradle.kts
@@ -8,4 +8,6 @@ dependencies {
 	api(project(":s2-spring:s2-spring-core"))
 	implementation(libs.spring.boot.autoconfigure)
 	kapt(libs.spring.boot.configuration.processor)
+
+	testImplementation(libs.bundles.test.junit)
 }


### PR DESCRIPTION
Adds a `check` target to `infra/make/libs.mk` running the Gradle `sonar` task. The shared `make-jvm-workflow` already executes `make check` (with `FIXERS_SONAR_TOKEN` in the environment, consumed by the fixers CheckPlugin's SonarQubeConfigurator), so SonarCloud analysis now runs inside the libs job — the analysis path Sonar recommends for Gradle projects. Same approach as komune-io/fixers-f2#114 and komune-io/fixers-c2#100.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a build check for running code-quality analysis with the current version.
  * Registered the check as a standard build command.
  * Updated security workflow configuration to avoid duplicate code-quality analysis.
* **Tests**
  * Improved test support across core, DSL, event-sourcing, and starter modules.
* **Enhancements**
  * Added coroutine integration support for reactive data sourcing and storing components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->