### PR TITLE
fix: SonarQube cleanup, saveAll persistence bug and coverage to ~75%

### DIFF
--- a/s2-automate/s2-automate-core/src/commonMain/kotlin/s2/automate/core/appevent/listener/AutomateListenerAdapter.kt
+++ b/s2-automate/s2-automate-core/src/commonMain/kotlin/s2/automate/core/appevent/listener/AutomateListenerAdapter.kt
@@ -19,27 +19,27 @@ import s2.dsl.automate.model.WithS2State
 open class AutomateListenerAdapter<STATE, ID, ENTITY, AUTOMATE> : AutomateListener<STATE, ID, ENTITY, AUTOMATE>
 		where STATE : S2State, ENTITY : WithS2State<STATE>, ENTITY : WithS2Id<ID> {
 
-	override fun automateStateEntered(event: AutomateStateEntered) {}
+	override fun automateStateEntered(event: AutomateStateEntered) { /* no-op by default, override to react to this event */ }
 
-	override fun automateStateExited(event: AutomateStateExited) {}
+	override fun automateStateExited(event: AutomateStateExited) { /* no-op by default, override to react to this event */ }
 
-	override fun automateTransitionNotAccepted(event: AutomateTransitionNotAccepted) {}
+	override fun automateTransitionNotAccepted(event: AutomateTransitionNotAccepted) { /* no-op by default, override to react to this event */ }
 
-	override fun automateInitTransitionStarted(event: AutomateInitTransitionStarted) {}
+	override fun automateInitTransitionStarted(event: AutomateInitTransitionStarted) { /* no-op by default, override to react to this event */ }
 
-	override fun automateInitTransitionEnded(event: AutomateInitTransitionEnded<STATE, ENTITY>) {}
+	override fun automateInitTransitionEnded(event: AutomateInitTransitionEnded<STATE, ENTITY>) { /* no-op by default, override to react to this event */ }
 
-	override fun automateTransitionStarted(event: AutomateTransitionStarted) {}
+	override fun automateTransitionStarted(event: AutomateTransitionStarted) { /* no-op by default, override to react to this event */ }
 
-	override fun automateTransitionEnded(event: AutomateTransitionEnded<STATE, ENTITY>) {}
+	override fun automateTransitionEnded(event: AutomateTransitionEnded<STATE, ENTITY>) { /* no-op by default, override to react to this event */ }
 
-	override fun automateTransitionError(event: AutomateTransitionError) {}
+	override fun automateTransitionError(event: AutomateTransitionError) { /* no-op by default, override to react to this event */ }
 
-	override fun automateSessionStarted(event: AutomateSessionStarted<AUTOMATE>) {}
+	override fun automateSessionStarted(event: AutomateSessionStarted<AUTOMATE>) { /* no-op by default, override to react to this event */ }
 
-	override fun automateSessionStopped(event: AutomateSessionStopped<AUTOMATE>) {}
+	override fun automateSessionStopped(event: AutomateSessionStopped<AUTOMATE>) { /* no-op by default, override to react to this event */ }
 
-	override fun automateSessionError(event: AutomateSessionError) {}
+	override fun automateSessionError(event: AutomateSessionError) { /* no-op by default, override to react to this event */ }
 
-	override fun automatePersistFailure(event: AutomatePersistFailure) {}
+	override fun automatePersistFailure(event: AutomatePersistFailure) { /* no-op by default, override to react to this event */ }
 }

--- a/s2-automate/s2-automate-core/src/commonMain/kotlin/s2/automate/core/engine/S2AutomateEngineBase.kt
+++ b/s2-automate/s2-automate-core/src/commonMain/kotlin/s2/automate/core/engine/S2AutomateEngineBase.kt
@@ -127,7 +127,6 @@ ENTITY : WithS2Id<ID> {
     protected suspend fun <COMMAND : S2Command<ID>> loadBatch(
         cmds: List<Envelope<COMMAND>>
     ): List<Pair<Envelope<COMMAND>, ENTITY?>> {
-        val byIds = cmds.associateBy { it.data.id }
         val ids = cmds.mapNotNull { it.data.id }.asFlow()
         val entities = mutableMapOf<Any, ENTITY?>()
         persister.load(automateContext, ids = ids).collect { entity ->

--- a/s2-automate/s2-automate-core/src/commonMain/kotlin/s2/automate/core/engine/S2AutomateEngineBase.kt
+++ b/s2-automate/s2-automate-core/src/commonMain/kotlin/s2/automate/core/engine/S2AutomateEngineBase.kt
@@ -23,8 +23,8 @@ import s2.automate.core.context.InitTransitionContext
 import s2.automate.core.context.TransitionAppliedContext
 import s2.automate.core.context.TransitionContext
 import s2.automate.core.error.AutomateException
-import s2.automate.core.error.ERROR_ENTITY_NOT_FOUND
-import s2.automate.core.error.ERROR_UNKNOWN
+import s2.automate.core.error.entityNotFoundError
+import s2.automate.core.error.unknownError
 import s2.automate.core.error.asException
 import s2.automate.core.guard.GuardVerifier
 import s2.automate.core.persist.AutomatePersister
@@ -99,9 +99,9 @@ ENTITY : WithS2Id<ID> {
             commandsChunk.asFlow().mapNotNull { it.data.id }.let { ids ->
                 persister.load(automateContext, ids = ids)
             }.map { entity ->
-                entity ?: throw ERROR_ENTITY_NOT_FOUND(entity?.s2Id().toString()).asException()
+                entity ?: throw entityNotFoundError(entity?.s2Id().toString()).asException()
                 val command: Envelope<COMMAND> = byIds[entity.s2Id()]
-                    ?: throw ERROR_ENTITY_NOT_FOUND(entity.s2Id().toString()).asException()
+                    ?: throw entityNotFoundError(entity.s2Id().toString()).asException()
                 val transitionContext = TransitionContext(
                     automateContext = automateContext,
                     from = entity.s2State(),
@@ -169,7 +169,7 @@ ENTITY : WithS2Id<ID> {
                     cmd,
                     PersistOutcome.Rejected<Nothing>(
                         msgId = cmd.id,
-                        error = ERROR_ENTITY_NOT_FOUND(cmdId.toString()),
+                        error = entityNotFoundError(cmdId.toString()),
                     ),
                 )
             }
@@ -214,7 +214,7 @@ ENTITY : WithS2Id<ID> {
         if (e is AutomateException) {
             throw e
         } else {
-            throw ERROR_UNKNOWN(e).asException()
+            throw unknownError(e).asException()
         }
     }
 

--- a/s2-automate/s2-automate-core/src/commonMain/kotlin/s2/automate/core/engine/S2AutomateOutcomeEngineImpl.kt
+++ b/s2-automate/s2-automate-core/src/commonMain/kotlin/s2/automate/core/engine/S2AutomateOutcomeEngineImpl.kt
@@ -17,8 +17,8 @@ import s2.automate.core.context.InitTransitionAppliedContext
 import s2.automate.core.context.TransitionAppliedContext
 import s2.automate.core.context.TransitionContext
 import s2.automate.core.error.AutomateException
-import s2.automate.core.error.ERROR_PERSIST_LAMBDA_THROW
-import s2.automate.core.error.ERROR_UNKNOWN
+import s2.automate.core.error.persistLambdaThrowError
+import s2.automate.core.error.unknownError
 import s2.automate.core.guard.GuardVerifier
 import s2.automate.core.persist.AutomatePersister
 import s2.automate.core.persist.PersistOutcome
@@ -197,11 +197,11 @@ ENTITY : WithS2Id<ID> {
         when (this) {
             is AutomateException -> PersistOutcome.Rejected(
                 msgId = msgId,
-                error = errors.firstOrNull() ?: ERROR_UNKNOWN(this),
+                error = errors.firstOrNull() ?: unknownError(this),
             )
             else -> PersistOutcome.Indeterminate(
                 msgId = msgId,
-                error = ERROR_PERSIST_LAMBDA_THROW(this),
+                error = persistLambdaThrowError(this),
             )
         }
 

--- a/s2-automate/s2-automate-core/src/commonMain/kotlin/s2/automate/core/error/AutomateError.kt
+++ b/s2-automate/s2-automate-core/src/commonMain/kotlin/s2/automate/core/error/AutomateError.kt
@@ -3,24 +3,24 @@ package s2.automate.core.error
 import s2.dsl.automate.S2Error
 import s2.dsl.automate.s2error
 
-@Suppress("FunctionNaming")
+@Suppress("FunctionNaming", "kotlin:S100")
 fun ERROR_UNKNOWN(e: Exception) =
 	s2error("ERROR_UNKNOWN",
 		"An unknown error has occurred.",
 			cause = e
 		)
 
-@Suppress("FunctionNaming")
+@Suppress("FunctionNaming", "kotlin:S100")
 fun ERROR_INVALID_TRANSITION(state: String, command: String) =
 	s2error("ERROR_INVALID_TRANSITION",
 		"Not available transition from $state with command $command",
 		mapOf("from" to state, "command" to command))
 
-@Suppress("FunctionNaming")
+@Suppress("FunctionNaming", "kotlin:S100")
 fun ERROR_ENTITY_NOT_FOUND(id: String) =
 	s2error("ERROR_ENTITY_NOT_FOUND", "Entity with id[$id] not found", mapOf("id" to id))
 
-@Suppress("FunctionNaming")
+@Suppress("FunctionNaming", "kotlin:S100")
 fun ERROR_PERSIST_LAMBDA_THROW(cause: Throwable) =
     s2error(
         code = "ERROR_PERSIST_LAMBDA_THROW",

--- a/s2-automate/s2-automate-core/src/commonMain/kotlin/s2/automate/core/error/AutomateError.kt
+++ b/s2-automate/s2-automate-core/src/commonMain/kotlin/s2/automate/core/error/AutomateError.kt
@@ -3,30 +3,42 @@ package s2.automate.core.error
 import s2.dsl.automate.S2Error
 import s2.dsl.automate.s2error
 
-@Suppress("FunctionNaming", "kotlin:S100")
-fun ERROR_UNKNOWN(e: Exception) =
+fun unknownError(e: Exception) =
 	s2error("ERROR_UNKNOWN",
 		"An unknown error has occurred.",
 			cause = e
 		)
 
-@Suppress("FunctionNaming", "kotlin:S100")
-fun ERROR_INVALID_TRANSITION(state: String, command: String) =
+fun invalidTransitionError(state: String, command: String) =
 	s2error("ERROR_INVALID_TRANSITION",
 		"Not available transition from $state with command $command",
 		mapOf("from" to state, "command" to command))
 
-@Suppress("FunctionNaming", "kotlin:S100")
-fun ERROR_ENTITY_NOT_FOUND(id: String) =
+fun entityNotFoundError(id: String) =
 	s2error("ERROR_ENTITY_NOT_FOUND", "Entity with id[$id] not found", mapOf("id" to id))
 
-@Suppress("FunctionNaming", "kotlin:S100")
-fun ERROR_PERSIST_LAMBDA_THROW(cause: Throwable) =
+fun persistLambdaThrowError(cause: Throwable) =
     s2error(
         code = "ERROR_PERSIST_LAMBDA_THROW",
         description = cause.message ?: cause::class.simpleName ?: "unknown",
         cause = cause,
     )
+
+@Deprecated("Use unknownError", ReplaceWith("unknownError(e)"))
+@Suppress("FunctionNaming", "kotlin:S100")
+fun ERROR_UNKNOWN(e: Exception) = unknownError(e)
+
+@Deprecated("Use invalidTransitionError", ReplaceWith("invalidTransitionError(state, command)"))
+@Suppress("FunctionNaming", "kotlin:S100")
+fun ERROR_INVALID_TRANSITION(state: String, command: String) = invalidTransitionError(state, command)
+
+@Deprecated("Use entityNotFoundError", ReplaceWith("entityNotFoundError(id)"))
+@Suppress("FunctionNaming", "kotlin:S100")
+fun ERROR_ENTITY_NOT_FOUND(id: String) = entityNotFoundError(id)
+
+@Deprecated("Use persistLambdaThrowError", ReplaceWith("persistLambdaThrowError(cause)"))
+@Suppress("FunctionNaming", "kotlin:S100")
+fun ERROR_PERSIST_LAMBDA_THROW(cause: Throwable) = persistLambdaThrowError(cause)
 
 fun S2Error.asException() = AutomateException(listOf(this), this.cause)
 

--- a/s2-automate/s2-automate-core/src/commonMain/kotlin/s2/automate/core/guard/TransitionStateGuard.kt
+++ b/s2-automate/s2-automate-core/src/commonMain/kotlin/s2/automate/core/guard/TransitionStateGuard.kt
@@ -1,7 +1,7 @@
 package s2.automate.core.guard
 
 import s2.automate.core.context.TransitionContext
-import s2.automate.core.error.ERROR_INVALID_TRANSITION
+import s2.automate.core.error.invalidTransitionError
 import s2.dsl.automate.Automate
 import s2.dsl.automate.Cmd
 import s2.dsl.automate.S2State
@@ -25,7 +25,7 @@ AUTOMATE : Automate {
 			GuardResult.valid()
 		} else {
 			GuardResult.error(
-				ERROR_INVALID_TRANSITION(state.toString(), "$cmd")
+				invalidTransitionError(state.toString(), "$cmd")
 			)
 		}
 	}

--- a/s2-automate/s2-automate-core/src/commonMain/kotlin/s2/automate/core/persist/AutomatePersister.kt
+++ b/s2-automate/s2-automate-core/src/commonMain/kotlin/s2/automate/core/persist/AutomatePersister.kt
@@ -9,8 +9,8 @@ import kotlinx.coroutines.flow.toList
 import s2.automate.core.context.AutomateContext
 import s2.automate.core.context.InitTransitionAppliedContext
 import s2.automate.core.context.TransitionAppliedContext
-import s2.automate.core.error.ERROR_ENTITY_NOT_FOUND
-import s2.automate.core.error.ERROR_PERSIST_LAMBDA_THROW
+import s2.automate.core.error.entityNotFoundError
+import s2.automate.core.error.persistLambdaThrowError
 import s2.dsl.automate.S2State
 import s2.dsl.automate.model.WithS2Id
 import s2.dsl.automate.model.WithS2State
@@ -71,7 +71,7 @@ ENTITY : WithS2Id<ID> {
 		}
 		if (failure != null) {
 			idList.forEach { id ->
-				emit(LoadOutcome.Transient<ID & Any, ENTITY>(id, ERROR_PERSIST_LAMBDA_THROW(failure)))
+				emit(LoadOutcome.Transient<ID & Any, ENTITY>(id, persistLambdaThrowError(failure)))
 			}
 			return@flow
 		}
@@ -80,7 +80,7 @@ ENTITY : WithS2Id<ID> {
 			if (entity != null) {
 				emit(LoadOutcome.Loaded(id, entity))
 			} else {
-				emit(LoadOutcome.Rejected(id, ERROR_ENTITY_NOT_FOUND(id.toString())))
+				emit(LoadOutcome.Rejected(id, entityNotFoundError(id.toString())))
 			}
 		}
 	}

--- a/s2-automate/s2-automate-core/src/commonMain/kotlin/s2/automate/core/storing/snap/RetryTaskChannel.kt
+++ b/s2-automate/s2-automate-core/src/commonMain/kotlin/s2/automate/core/storing/snap/RetryTaskChannel.kt
@@ -27,7 +27,7 @@ class RetryTaskChannel(
     override val coroutineContext: CoroutineContext
         get() = Dispatchers.Default + supervisorJob
 
-    private val persistChannel = Channel<RetryTask<Any, Any, Any>>()
+    private val persistChannel = Channel<suspend () -> Unit>()
 
     init {
         launchPersistWorker()
@@ -35,10 +35,7 @@ class RetryTaskChannel(
 
     private fun CoroutineScope.launchPersistWorker() = launch {
         for (task in persistChannel) {
-            val result = retry {
-                task.persist(task.event)
-            }
-            task.result.complete(result)
+            task()
         }
     }
 
@@ -48,8 +45,10 @@ class RetryTaskChannel(
         persist: suspend (EVENT) -> Pair<ENTITY, EVENT>
     ): Pair<ENTITY, EVENT> {
         val resultDeferred = CompletableDeferred<Pair<Pair<ENTITY, EVENT>?, Throwable?>>()
-        val task = RetryTask(id, event, resultDeferred, persist) as RetryTask<Any, Any, Any>
-        persistChannel.send(task)
+        val task = RetryTask(id, event, resultDeferred, persist)
+        persistChannel.send {
+            task.result.complete(retry { task.persist(task.event) })
+        }
         val (entity, exception) = resultDeferred.await()
         if(exception != null) throw exception
         return entity!!

--- a/s2-automate/s2-automate-core/src/commonMain/kotlin/s2/automate/core/storing/snap/RetryTaskChannel.kt
+++ b/s2-automate/s2-automate-core/src/commonMain/kotlin/s2/automate/core/storing/snap/RetryTaskChannel.kt
@@ -2,6 +2,7 @@ package s2.automate.core.storing.snap
 
 import kotlin.coroutines.CoroutineContext
 import kotlin.reflect.KClass
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -35,7 +36,14 @@ class RetryTaskChannel(
 
     private fun CoroutineScope.launchPersistWorker() = launch {
         for (task in persistChannel) {
-            task()
+            try {
+                task()
+            } catch (e: CancellationException) {
+                throw e
+            } catch (@Suppress("TooGenericExceptionCaught") e: Throwable) {
+                // a failing task must not kill the single worker, or every
+                // subsequent addToPersistQueue send would suspend forever
+            }
         }
     }
 

--- a/s2-automate/s2-automate-core/src/commonMain/kotlin/s2/automate/core/storing/snap/SnapPersister.kt
+++ b/s2-automate/s2-automate-core/src/commonMain/kotlin/s2/automate/core/storing/snap/SnapPersister.kt
@@ -1,7 +1,7 @@
 package s2.automate.core.storing.snap
 
 import kotlinx.coroutines.flow.flowOf
-import s2.automate.core.error.ERROR_ENTITY_NOT_FOUND
+import s2.automate.core.error.entityNotFoundError
 import s2.automate.core.error.asException
 import s2.dsl.automate.Evt
 import s2.dsl.automate.S2State
@@ -29,7 +29,7 @@ EVENT : WithS2Id<ID> {
     private suspend fun persistSnap(event: EVENT): Pair<ENTITY, EVENT> {
         val id = event.s2Id()
         val entityMutated = projectionLoader.loadAndEvolve(id, flowOf(event))
-            ?: throw ERROR_ENTITY_NOT_FOUND(event.s2Id().toString()).asException()
+            ?: throw entityNotFoundError(event.s2Id().toString()).asException()
         val entity = snapRepository?.save(entityMutated) ?: entityMutated
         return entity to event
     }

--- a/s2-automate/s2-automate-core/src/commonTest/kotlin/s2/automate/core/engine/S2AutomateOutcomeEngineImplOuterExceptionTest.kt
+++ b/s2-automate/s2-automate-core/src/commonTest/kotlin/s2/automate/core/engine/S2AutomateOutcomeEngineImplOuterExceptionTest.kt
@@ -18,7 +18,7 @@ import s2.automate.core.context.InitTransitionAppliedContext
 import s2.automate.core.context.InitTransitionContext
 import s2.automate.core.context.TransitionAppliedContext
 import s2.automate.core.context.TransitionContext
-import s2.automate.core.error.ERROR_INVALID_TRANSITION
+import s2.automate.core.error.invalidTransitionError
 import s2.automate.core.error.asException
 import s2.automate.core.guard.GuardVerifier
 import s2.automate.core.persist.AutomatePersister
@@ -96,13 +96,13 @@ class S2AutomateOutcomeEngineImplOuterExceptionTest {
         GuardVerifier<TestState, String, TestEntity, TestEvent, S2Automate> {
 
         override suspend fun evaluateInit(context: InitTransitionContext<S2Automate>) {
-            throw ERROR_INVALID_TRANSITION("any", "guard-reject").asException()
+            throw invalidTransitionError("any", "guard-reject").asException()
         }
 
         override suspend fun <COMMAND : Cmd> evaluateTransition(
             context: TransitionContext<TestState, String, TestEntity, S2Automate, COMMAND>
         ) {
-            throw ERROR_INVALID_TRANSITION("any", "guard-reject").asException()
+            throw invalidTransitionError("any", "guard-reject").asException()
         }
 
         override suspend fun verifyInitTransition(

--- a/s2-automate/s2-automate-core/src/jvmTest/kotlin/s2/automate/core/appevent/AutomateEventPublisherTest.kt
+++ b/s2-automate/s2-automate-core/src/jvmTest/kotlin/s2/automate/core/appevent/AutomateEventPublisherTest.kt
@@ -1,0 +1,124 @@
+package s2.automate.core.appevent
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import s2.automate.core.appevent.listener.AutomateListenerAdapter
+import s2.automate.core.appevent.publisher.AppEventPublisher
+import s2.automate.core.appevent.publisher.AutomateEventPublisher
+import s2.automate.core.persist.AutomatePersistFailure
+import s2.dsl.automate.ErrorCategory
+import s2.dsl.automate.S2Automate
+import s2.dsl.automate.S2InitCommand
+import s2.dsl.automate.S2State
+import s2.dsl.automate.model.WithS2Id
+import s2.dsl.automate.model.WithS2State
+import s2.dsl.automate.s2error
+
+class AutomateEventPublisherTest {
+
+    enum class TestState(override val position: Int) : S2State {
+        Created(0), Active(1)
+    }
+
+    data class TestEntity(val id: String, val state: TestState) : WithS2Id<String>, WithS2State<TestState> {
+        override fun s2Id(): String = id
+        override fun s2State(): TestState = state
+    }
+
+    data class CreateCmd(val id: String) : S2InitCommand
+
+    private class RecordingPublisher : AppEventPublisher {
+        val published = mutableListOf<Any>()
+        override fun <EVENT> publish(event: EVENT & Any) {
+            published.add(event)
+        }
+    }
+
+    private val automate = S2Automate(name = "Test", version = null, transitions = emptyArray())
+    private val entity = TestEntity("1", TestState.Created)
+    private val cmd = CreateCmd("1")
+
+    private fun allEvents(): List<AppEvent> = listOf(
+        AutomateStateEntered(TestState.Created),
+        AutomateStateExited(TestState.Created),
+        AutomateTransitionNotAccepted(TestState.Created, cmd),
+        AutomateInitTransitionStarted(cmd),
+        AutomateInitTransitionEnded(TestState.Created, cmd, entity),
+        AutomateTransitionStarted(TestState.Created, cmd),
+        AutomateTransitionEnded(TestState.Created, TestState.Active, cmd, entity),
+        AutomateTransitionError(cmd, IllegalStateException("boom")),
+        AutomateSessionStarted(automate),
+        AutomateSessionStopped(automate),
+        AutomateSessionError(automate, IllegalStateException("boom")),
+        AutomatePersistFailure("msg-1", ErrorCategory.Transient, s2error("ERR", "desc")),
+    )
+
+    private fun dispatch(
+        listener: s2.automate.core.appevent.listener.AutomateListener<TestState, String, TestEntity, S2Automate>,
+        events: List<AppEvent>,
+    ) {
+        events.forEach { event ->
+            @Suppress("UNCHECKED_CAST")
+            when (event) {
+                is AutomateStateEntered -> listener.automateStateEntered(event)
+                is AutomateStateExited -> listener.automateStateExited(event)
+                is AutomateTransitionNotAccepted -> listener.automateTransitionNotAccepted(event)
+                is AutomateInitTransitionStarted -> listener.automateInitTransitionStarted(event)
+                is AutomateInitTransitionEnded<*, *> ->
+                    listener.automateInitTransitionEnded(event as AutomateInitTransitionEnded<TestState, TestEntity>)
+                is AutomateTransitionStarted -> listener.automateTransitionStarted(event)
+                is AutomateTransitionEnded<*, *> ->
+                    listener.automateTransitionEnded(event as AutomateTransitionEnded<TestState, TestEntity>)
+                is AutomateTransitionError -> listener.automateTransitionError(event)
+                is AutomateSessionStarted<*> ->
+                    listener.automateSessionStarted(event as AutomateSessionStarted<S2Automate>)
+                is AutomateSessionStopped<*> ->
+                    listener.automateSessionStopped(event as AutomateSessionStopped<S2Automate>)
+                is AutomateSessionError -> listener.automateSessionError(event)
+                is AutomatePersistFailure -> listener.automatePersistFailure(event)
+                else -> error("Unhandled event $event")
+            }
+        }
+    }
+
+    @Test
+    fun `AutomateEventPublisher forwards every listener callback to the publisher`() {
+        val publisher = RecordingPublisher()
+        val automatePublisher = AutomateEventPublisher<TestState, String, TestEntity, S2Automate>(publisher)
+        val events = allEvents()
+        dispatch(automatePublisher, events)
+        assertEquals(events.size, publisher.published.size)
+        events.zip(publisher.published).forEach { (sent, received) ->
+            assertSame(sent, received)
+        }
+    }
+
+    @Test
+    fun `AutomateListenerAdapter ignores every event by default`() {
+        val adapter = AutomateListenerAdapter<TestState, String, TestEntity, S2Automate>()
+        // Must not throw: every callback is an explicit no-op.
+        dispatch(adapter, allEvents())
+        assertTrue(true)
+    }
+
+    @Test
+    fun `app events expose their payload`() {
+        val notAccepted = AutomateTransitionNotAccepted(TestState.Created, cmd)
+        assertEquals(TestState.Created, notAccepted.from)
+        assertEquals(cmd, notAccepted.msg)
+
+        val initEnded = AutomateInitTransitionEnded(TestState.Created, cmd, entity)
+        assertEquals(TestState.Created, initEnded.to)
+        assertEquals(entity, initEnded.entity)
+
+        val ended = AutomateTransitionEnded(TestState.Created, TestState.Active, cmd, entity)
+        assertEquals(TestState.Created, ended.from)
+        assertEquals(TestState.Active, ended.to)
+
+        val sessionError = AutomateSessionError(automate, null)
+        assertEquals(automate, sessionError.automate)
+        assertEquals(null, sessionError.exception)
+    }
+}

--- a/s2-automate/s2-automate-core/src/jvmTest/kotlin/s2/automate/core/config/S2PropertiesTest.kt
+++ b/s2-automate/s2-automate-core/src/jvmTest/kotlin/s2/automate/core/config/S2PropertiesTest.kt
@@ -1,0 +1,34 @@
+package s2.automate.core.config
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import s2.automate.core.context.AutomateContext
+import s2.automate.core.context.asBatch
+
+class S2PropertiesTest {
+
+    @Test
+    fun `S2RetryTaskProperties has sensible defaults`() {
+        val properties = S2RetryTaskProperties()
+        assertEquals(5, properties.maxAttempts)
+        assertEquals(1000L, properties.delayMillis)
+        val custom = S2RetryTaskProperties(maxAttempts = 2, delayMillis = 10)
+        assertEquals(2, custom.maxAttempts)
+        assertEquals(10L, custom.delayMillis)
+    }
+
+    @Test
+    fun `asBatch maps size and concurrency`() {
+        val batch = S2BatchProperties(size = 7, concurrency = 3).asBatch()
+        assertEquals(7, batch.size)
+        assertEquals(3, batch.concurrency)
+    }
+
+    @Test
+    fun `AutomateContext exposes automate and batch`() {
+        val properties = S2BatchProperties(size = 1, concurrency = 1)
+        val context = AutomateContext(automate = "AUTOMATE", batch = properties)
+        assertEquals("AUTOMATE", context.automate)
+        assertEquals(properties, context.batch)
+    }
+}

--- a/s2-automate/s2-automate-core/src/jvmTest/kotlin/s2/automate/core/engine/LoadedSlotTest.kt
+++ b/s2-automate/s2-automate-core/src/jvmTest/kotlin/s2/automate/core/engine/LoadedSlotTest.kt
@@ -1,0 +1,56 @@
+package s2.automate.core.engine
+
+import f2.dsl.cqrs.envelope.asEnvelopeWithType
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Test
+import s2.automate.core.persist.LoadOutcome
+import s2.automate.core.persist.PersistOutcome
+import s2.dsl.automate.ErrorCategory
+import s2.dsl.automate.s2error
+
+class LoadedSlotTest {
+
+    @Test
+    fun `LoadOutcome variants carry their category`() {
+        val error = s2error("ERR", "desc")
+        assertEquals(ErrorCategory.Rejected, LoadOutcome.Rejected<String, String>("1", error).category)
+        assertEquals(ErrorCategory.Transient, LoadOutcome.Transient<String, String>("1", error).category)
+        assertEquals(ErrorCategory.Indeterminate, LoadOutcome.Indeterminate<String, String>("1", error).category)
+        assertEquals(ErrorCategory.Conflict, LoadOutcome.Conflict<String, String>("1", error).category)
+        val loaded = LoadOutcome.Loaded("1", "ENTITY")
+        assertEquals("1", loaded.id)
+        assertEquals("ENTITY", loaded.entity)
+    }
+
+    @Test
+    fun `toPersistFailure maps every load failure to the same persist category`() {
+        val error = s2error("ERR", "desc")
+        val rejected = LoadOutcome.Rejected<String, String>("1", error).toPersistFailure("msg")
+        val transient = LoadOutcome.Transient<String, String>("1", error).toPersistFailure("msg")
+        val indeterminate = LoadOutcome.Indeterminate<String, String>("1", error).toPersistFailure("msg")
+        val conflict = LoadOutcome.Conflict<String, String>("1", error).toPersistFailure("msg")
+
+        assertEquals(PersistOutcome.Rejected<Nothing>("msg", error), rejected)
+        assertEquals(PersistOutcome.Transient<Nothing>("msg", error), transient)
+        assertEquals(PersistOutcome.Indeterminate<Nothing>("msg", error), indeterminate)
+        assertEquals(PersistOutcome.Conflict<Nothing>("msg", error), conflict)
+        listOf(rejected, transient, indeterminate, conflict).forEach {
+            assertEquals("msg", it.msgId)
+            assertSame(error, it.error)
+        }
+    }
+
+    @Test
+    fun `LoadedSlot Ready and Failed expose their command envelope`() {
+        val envelope = "CMD".asEnvelopeWithType("Cmd")
+        val ready = LoadedSlot.Ready(envelope, "ENTITY")
+        assertSame(envelope, ready.cmd)
+        assertEquals("ENTITY", ready.entity)
+
+        val failure = PersistOutcome.Rejected<Nothing>("msg", s2error("ERR", "desc"))
+        val failed = LoadedSlot.Failed<String, String>(envelope, failure)
+        assertSame(envelope, failed.cmd)
+        assertSame(failure, failed.failure)
+    }
+}

--- a/s2-automate/s2-automate-core/src/jvmTest/kotlin/s2/automate/core/engine/S2AutomateEngineImplTest.kt
+++ b/s2-automate/s2-automate-core/src/jvmTest/kotlin/s2/automate/core/engine/S2AutomateEngineImplTest.kt
@@ -1,0 +1,210 @@
+package s2.automate.core.engine
+
+import f2.dsl.cqrs.envelope.Envelope
+import f2.dsl.cqrs.envelope.asEnvelopeWithType
+import f2.dsl.fnc.operators.mapToEnvelopeWithRandomId
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.toList
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import s2.automate.core.appevent.AutomateInitTransitionStarted
+import s2.automate.core.appevent.AutomateSessionStopped
+import s2.automate.core.appevent.AutomateTransitionEnded
+import s2.automate.core.appevent.AutomateTransitionError
+import s2.automate.core.appevent.AutomateTransitionStarted
+import s2.automate.core.appevent.publisher.AppEventPublisher
+import s2.automate.core.appevent.publisher.AutomateEventPublisher
+import s2.automate.core.config.S2BatchProperties
+import s2.automate.core.context.AutomateContext
+import s2.automate.core.context.InitTransitionAppliedContext
+import s2.automate.core.context.InitTransitionContext
+import s2.automate.core.context.TransitionAppliedContext
+import s2.automate.core.context.TransitionContext
+import s2.automate.core.error.AutomateException
+import s2.automate.core.guard.GuardVerifier
+import s2.automate.core.persist.AutomatePersister
+import s2.dsl.automate.Cmd
+import s2.dsl.automate.S2Automate
+import s2.dsl.automate.S2Command
+import s2.dsl.automate.S2InitCommand
+import s2.dsl.automate.S2Role
+import s2.dsl.automate.S2State
+import s2.dsl.automate.builder.s2
+import s2.dsl.automate.model.WithS2Id
+import s2.dsl.automate.model.WithS2State
+
+class S2AutomateEngineImplTest {
+
+    enum class TestState(override val position: Int) : S2State {
+        Created(0), Active(1)
+    }
+
+    object TestRole : S2Role
+
+    data class TestEntity(val id: String, val state: TestState) : WithS2Id<String>, WithS2State<TestState> {
+        override fun s2Id(): String = id
+        override fun s2State(): TestState = state
+    }
+
+    data class CreateCmd(val id: String) : S2InitCommand
+    data class DoCmd(override val id: String) : S2Command<String>
+
+    sealed interface TestEvent {
+        val entityId: String
+    }
+
+    data class CreatedEvt(override val entityId: String) : TestEvent
+    data class DoneEvt(override val entityId: String) : TestEvent
+
+    private val automate: S2Automate = s2 {
+        name = "EngineTest"
+        init<CreateCmd> {
+            to = TestState.Created
+            role = TestRole
+        }
+        transaction<DoCmd> {
+            from = TestState.Created
+            to = TestState.Active
+            role = TestRole
+        }
+    }
+
+    private class StubPersister(
+        private val entities: Map<String, TestEntity>,
+    ) : AutomatePersister<TestState, String, TestEntity, TestEvent, S2Automate> {
+
+        override suspend fun load(
+            automateContexts: AutomateContext<S2Automate>,
+            id: String,
+        ): TestEntity? = entities[id]
+
+        override suspend fun load(
+            automateContexts: AutomateContext<S2Automate>,
+            ids: Flow<String>,
+        ): Flow<TestEntity?> = ids.map { entities[it] }
+
+        override suspend fun persistInit(
+            transitionContexts: Flow<InitTransitionAppliedContext<TestState, String, TestEntity, TestEvent, S2Automate>>
+        ): Flow<TestEvent> = transitionContexts.map { it.event }
+
+        override suspend fun persist(
+            transitionContexts: Flow<TransitionAppliedContext<TestState, String, TestEntity, TestEvent, S2Automate>>
+        ): Flow<TestEvent> = transitionContexts.map { it.event }
+    }
+
+    private class RecordingPublisher : AppEventPublisher {
+        val published = mutableListOf<Any>()
+        override fun <EVENT> publish(event: EVENT & Any) {
+            published.add(event)
+        }
+    }
+
+    private class PassthroughGuardVerifier : GuardVerifier<TestState, String, TestEntity, TestEvent, S2Automate> {
+        var evaluateInitCount = 0
+        var evaluateTransitionCount = 0
+        var verifyInitCount = 0
+        var verifyTransitionCount = 0
+
+        override suspend fun evaluateInit(context: InitTransitionContext<S2Automate>) {
+            evaluateInitCount++
+        }
+
+        override suspend fun <COMMAND : Cmd> evaluateTransition(
+            context: TransitionContext<TestState, String, TestEntity, S2Automate, COMMAND>
+        ) {
+            evaluateTransitionCount++
+        }
+
+        override suspend fun verifyInitTransition(
+            context: InitTransitionAppliedContext<TestState, String, TestEntity, TestEvent, S2Automate>
+        ): InitTransitionAppliedContext<TestState, String, TestEntity, TestEvent, S2Automate> {
+            verifyInitCount++
+            return context
+        }
+
+        override suspend fun verifyTransition(
+            context: TransitionAppliedContext<TestState, String, TestEntity, TestEvent, S2Automate>
+        ): TransitionAppliedContext<TestState, String, TestEntity, TestEvent, S2Automate> {
+            verifyTransitionCount++
+            return context
+        }
+    }
+
+    private fun engine(
+        guard: PassthroughGuardVerifier = PassthroughGuardVerifier(),
+        publisher: RecordingPublisher = RecordingPublisher(),
+        entities: Map<String, TestEntity> = mapOf("1" to TestEntity("1", TestState.Created)),
+    ): S2AutomateEngineImpl<TestState, String, TestEntity, TestEvent> {
+        val automateContext = AutomateContext(automate, S2BatchProperties(size = 10))
+        val automatePublisher = AutomateEventPublisher<TestState, String, TestEntity, S2Automate>(publisher)
+        return S2AutomateEngineImpl(automateContext, guard, StubPersister(entities), automatePublisher)
+    }
+
+    @Test
+    suspend fun `create decides guards and persists every command`() {
+        val guard = PassthroughGuardVerifier()
+        val publisher = RecordingPublisher()
+        val engine = engine(guard, publisher)
+
+        val commands = flowOf(CreateCmd("1"), CreateCmd("2")).mapToEnvelopeWithRandomId(type = "Cmd")
+        val events = engine.create(commands) { cmd ->
+            TestEntity(cmd.data.id, TestState.Created) to CreatedEvt(cmd.data.id).asEnvelopeWithType("Evt")
+        }.toList()
+
+        assertEquals(listOf("1", "2"), events.map { it.data.entityId })
+        assertEquals(2, guard.evaluateInitCount)
+        assertEquals(2, guard.verifyInitCount)
+        assertEquals(2, publisher.published.filterIsInstance<AutomateInitTransitionStarted>().size)
+    }
+
+    @Test
+    suspend fun `create maps unexpected decide failures to ERROR_UNKNOWN`() {
+        val publisher = RecordingPublisher()
+        val engine = engine(publisher = publisher)
+
+        val commands = flowOf(CreateCmd("1")).mapToEnvelopeWithRandomId(type = "Cmd")
+        val exception = assertThrows<AutomateException> {
+            engine.create<CreateCmd, TestEntity, CreatedEvt>(commands) { _ ->
+                throw IllegalStateException("decide failed")
+            }.toList()
+        }
+        assertEquals("ERROR_UNKNOWN", exception.errors.single().type)
+        assertEquals(1, publisher.published.filterIsInstance<AutomateTransitionError>().size)
+    }
+
+    @Test
+    suspend fun `doTransition executes guards persists and publishes lifecycle events`() {
+        val guard = PassthroughGuardVerifier()
+        val publisher = RecordingPublisher()
+        val engine = engine(guard, publisher)
+
+        val commands = flowOf(DoCmd("1")).mapToEnvelopeWithRandomId(type = "Cmd")
+        val events = engine.doTransition(commands) { cmd, entity ->
+            TestEntity(entity.id, TestState.Active) to DoneEvt(cmd.data.id).asEnvelopeWithType("Evt")
+        }.toList()
+
+        assertEquals(listOf("1"), events.map { it.data.entityId })
+        assertEquals(1, guard.evaluateTransitionCount)
+        assertEquals(1, guard.verifyTransitionCount)
+        assertEquals(1, publisher.published.filterIsInstance<AutomateTransitionStarted>().size)
+        assertEquals(1, publisher.published.filterIsInstance<AutomateTransitionEnded<*, *>>().size)
+        // Active is a final state: the automate session stops.
+        assertEquals(1, publisher.published.filterIsInstance<AutomateSessionStopped<*>>().size)
+    }
+
+    @Test
+    suspend fun `doTransition fails with ERROR_ENTITY_NOT_FOUND when the entity is missing`() {
+        val engine = engine(entities = emptyMap())
+        val commands = flowOf(DoCmd("missing")).mapToEnvelopeWithRandomId(type = "Cmd")
+        val exception = assertThrows<AutomateException> {
+            engine.doTransition(commands) { cmd, entity ->
+                TestEntity(entity.id, TestState.Active) to DoneEvt(cmd.data.id).asEnvelopeWithType("Evt")
+            }.toList()
+        }
+        assertTrue(exception.errors.single().type == "ERROR_ENTITY_NOT_FOUND")
+    }
+}

--- a/s2-automate/s2-automate-core/src/jvmTest/kotlin/s2/automate/core/error/AutomateErrorTest.kt
+++ b/s2-automate/s2-automate-core/src/jvmTest/kotlin/s2/automate/core/error/AutomateErrorTest.kt
@@ -11,17 +11,17 @@ import s2.dsl.automate.s2error
 class AutomateErrorTest {
 
     @Test
-    fun `ERROR_UNKNOWN wraps the cause`() {
+    fun `unknownError wraps the cause`() {
         val cause = IllegalStateException("boom")
-        val error = ERROR_UNKNOWN(cause)
+        val error = unknownError(cause)
         assertEquals("ERROR_UNKNOWN", error.type)
         assertEquals("An unknown error has occurred.", error.description)
         assertSame(cause, error.cause)
     }
 
     @Test
-    fun `ERROR_INVALID_TRANSITION carries state and command in payload`() {
-        val error = ERROR_INVALID_TRANSITION("Created", "DoCmd")
+    fun `invalidTransitionError carries state and command in payload`() {
+        val error = invalidTransitionError("Created", "DoCmd")
         assertEquals("ERROR_INVALID_TRANSITION", error.type)
         assertEquals("Created", error.payload["from"])
         assertEquals("DoCmd", error.payload["command"])
@@ -29,31 +29,44 @@ class AutomateErrorTest {
     }
 
     @Test
-    fun `ERROR_ENTITY_NOT_FOUND carries the id in payload`() {
-        val error = ERROR_ENTITY_NOT_FOUND("42")
+    fun `entityNotFoundError carries the id in payload`() {
+        val error = entityNotFoundError("42")
         assertEquals("ERROR_ENTITY_NOT_FOUND", error.type)
         assertEquals("42", error.payload["id"])
         assertTrue(error.description.contains("42"))
     }
 
     @Test
-    fun `ERROR_PERSIST_LAMBDA_THROW uses the cause message`() {
-        val error = ERROR_PERSIST_LAMBDA_THROW(IllegalStateException("boom"))
+    fun `persistLambdaThrowError uses the cause message`() {
+        val error = persistLambdaThrowError(IllegalStateException("boom"))
         assertEquals("ERROR_PERSIST_LAMBDA_THROW", error.type)
         assertEquals("boom", error.description)
     }
 
     @Test
-    fun `ERROR_PERSIST_LAMBDA_THROW falls back to the cause class name`() {
-        val error = ERROR_PERSIST_LAMBDA_THROW(IllegalStateException())
+    fun `persistLambdaThrowError falls back to the cause class name`() {
+        val error = persistLambdaThrowError(IllegalStateException())
         assertEquals("IllegalStateException", error.description)
     }
 
     @Test
-    fun `ERROR_PERSIST_LAMBDA_THROW falls back to unknown for anonymous causes`() {
+    fun `persistLambdaThrowError falls back to unknown for anonymous causes`() {
         val anonymous = object : Exception() {}
-        val error = ERROR_PERSIST_LAMBDA_THROW(anonymous)
+        val error = persistLambdaThrowError(anonymous)
         assertEquals("unknown", error.description)
+    }
+
+    @Test
+    @Suppress("DEPRECATION")
+    fun `deprecated ERROR_ shims delegate to the renamed functions`() {
+        val cause = IllegalStateException("boom")
+        assertEquals(unknownError(cause).type, ERROR_UNKNOWN(cause).type)
+        assertEquals(
+            invalidTransitionError("Created", "DoCmd").payload,
+            ERROR_INVALID_TRANSITION("Created", "DoCmd").payload
+        )
+        assertEquals(entityNotFoundError("42").payload, ERROR_ENTITY_NOT_FOUND("42").payload)
+        assertEquals(persistLambdaThrowError(cause).description, ERROR_PERSIST_LAMBDA_THROW(cause).description)
     }
 
     @Test

--- a/s2-automate/s2-automate-core/src/jvmTest/kotlin/s2/automate/core/error/AutomateErrorTest.kt
+++ b/s2-automate/s2-automate-core/src/jvmTest/kotlin/s2/automate/core/error/AutomateErrorTest.kt
@@ -1,0 +1,76 @@
+package s2.automate.core.error
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import s2.dsl.automate.s2error
+
+class AutomateErrorTest {
+
+    @Test
+    fun `ERROR_UNKNOWN wraps the cause`() {
+        val cause = IllegalStateException("boom")
+        val error = ERROR_UNKNOWN(cause)
+        assertEquals("ERROR_UNKNOWN", error.type)
+        assertEquals("An unknown error has occurred.", error.description)
+        assertSame(cause, error.cause)
+    }
+
+    @Test
+    fun `ERROR_INVALID_TRANSITION carries state and command in payload`() {
+        val error = ERROR_INVALID_TRANSITION("Created", "DoCmd")
+        assertEquals("ERROR_INVALID_TRANSITION", error.type)
+        assertEquals("Created", error.payload["from"])
+        assertEquals("DoCmd", error.payload["command"])
+        assertTrue(error.description.contains("Created"))
+    }
+
+    @Test
+    fun `ERROR_ENTITY_NOT_FOUND carries the id in payload`() {
+        val error = ERROR_ENTITY_NOT_FOUND("42")
+        assertEquals("ERROR_ENTITY_NOT_FOUND", error.type)
+        assertEquals("42", error.payload["id"])
+        assertTrue(error.description.contains("42"))
+    }
+
+    @Test
+    fun `ERROR_PERSIST_LAMBDA_THROW uses the cause message`() {
+        val error = ERROR_PERSIST_LAMBDA_THROW(IllegalStateException("boom"))
+        assertEquals("ERROR_PERSIST_LAMBDA_THROW", error.type)
+        assertEquals("boom", error.description)
+    }
+
+    @Test
+    fun `ERROR_PERSIST_LAMBDA_THROW falls back to the cause class name`() {
+        val error = ERROR_PERSIST_LAMBDA_THROW(IllegalStateException())
+        assertEquals("IllegalStateException", error.description)
+    }
+
+    @Test
+    fun `ERROR_PERSIST_LAMBDA_THROW falls back to unknown for anonymous causes`() {
+        val anonymous = object : Exception() {}
+        val error = ERROR_PERSIST_LAMBDA_THROW(anonymous)
+        assertEquals("unknown", error.description)
+    }
+
+    @Test
+    fun `asException builds an AutomateException carrying the error`() {
+        val cause = IllegalStateException("boom")
+        val exception = s2error("CODE", "desc", cause = cause).asException()
+        assertEquals(1, exception.errors.size)
+        assertEquals("CODE", exception.errors.first().type)
+        assertSame(cause, exception.cause)
+    }
+
+    @Test
+    fun `throwException throws an AutomateException`() {
+        val exception = assertThrows<AutomateException> {
+            s2error("CODE", "desc").throwException()
+        }
+        assertEquals("CODE", exception.errors.single().type)
+        assertNull(exception.cause)
+    }
+}

--- a/s2-automate/s2-automate-core/src/jvmTest/kotlin/s2/automate/core/guard/GuardTest.kt
+++ b/s2-automate/s2-automate-core/src/jvmTest/kotlin/s2/automate/core/guard/GuardTest.kt
@@ -1,0 +1,214 @@
+package s2.automate.core.guard
+
+import f2.dsl.cqrs.envelope.asEnvelopeWithType
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import s2.automate.core.appevent.AutomateTransitionNotAccepted
+import s2.automate.core.appevent.publisher.AppEventPublisher
+import s2.automate.core.appevent.publisher.AutomateEventPublisher
+import s2.automate.core.config.S2BatchProperties
+import s2.automate.core.context.AutomateContext
+import s2.automate.core.context.InitTransitionAppliedContext
+import s2.automate.core.context.InitTransitionContext
+import s2.automate.core.context.TransitionAppliedContext
+import s2.automate.core.context.TransitionContext
+import s2.automate.core.error.AutomateException
+import s2.dsl.automate.S2Automate
+import s2.dsl.automate.S2Command
+import s2.dsl.automate.S2InitCommand
+import s2.dsl.automate.S2Role
+import s2.dsl.automate.S2State
+import s2.dsl.automate.builder.s2
+import s2.dsl.automate.model.WithS2Id
+import s2.dsl.automate.model.WithS2State
+import s2.dsl.automate.s2error
+
+class GuardTest {
+
+    enum class TestState(override val position: Int) : S2State {
+        Created(0), Active(1)
+    }
+
+    object TestRole : S2Role
+
+    data class TestEntity(val id: String, val state: TestState) : WithS2Id<String>, WithS2State<TestState> {
+        override fun s2Id(): String = id
+        override fun s2State(): TestState = state
+    }
+
+    data class CreateCmd(val id: String) : S2InitCommand
+    data class DoCmd(override val id: String) : S2Command<String>
+    data class OtherCmd(override val id: String) : S2Command<String>
+
+    private val automate: S2Automate = s2 {
+        name = "GuardTest"
+        init<CreateCmd> {
+            to = TestState.Created
+            role = TestRole
+        }
+        transaction<DoCmd> {
+            from = TestState.Created
+            to = TestState.Active
+            role = TestRole
+        }
+    }
+
+    private val automateContext = AutomateContext(automate, S2BatchProperties())
+
+    private class RecordingPublisher : AppEventPublisher {
+        val published = mutableListOf<Any>()
+        override fun <EVENT> publish(event: EVENT & Any) {
+            published.add(event)
+        }
+    }
+
+    private fun automatePublisher(publisher: RecordingPublisher) =
+        AutomateEventPublisher<TestState, String, TestEntity, S2Automate>(publisher)
+
+    private fun transitionContext(entity: TestEntity, cmd: S2Command<String>) =
+        TransitionContext<TestState, String, TestEntity, S2Automate, S2Command<String>>(
+            automateContext = automateContext,
+            from = entity.s2State(),
+            command = cmd.asEnvelopeWithType("Cmd"),
+            entity = entity,
+        )
+
+    // ---- GuardResult ----
+
+    @Test
+    fun `GuardResult valid has no errors`() {
+        val result = GuardResult.valid()
+        assertTrue(result.isValid())
+        assertTrue(result.errors.isEmpty())
+    }
+
+    @Test
+    fun `GuardResult error from vararg and list is invalid`() {
+        val error = s2error("E1", "first")
+        assertFalse(GuardResult.error(error).isValid())
+        val fromList = GuardResult.error(listOf(error, s2error("E2", "second")))
+        assertFalse(fromList.isValid())
+        assertEquals(2, fromList.errors.size)
+    }
+
+    // ---- GuardAdapter ----
+
+    @Test
+    suspend fun `GuardAdapter accepts everything by default`() {
+        val adapter = GuardAdapter<TestState, String, TestEntity, String, S2Automate>()
+        val entity = TestEntity("1", TestState.Created)
+        assertTrue(adapter.evaluateInit(InitTransitionContext(automateContext, CreateCmd("1"))).isValid())
+        assertTrue(adapter.evaluateTransition(transitionContext(entity, DoCmd("1"))).isValid())
+        assertTrue(
+            adapter.verifyInitTransition(
+                InitTransitionAppliedContext(automateContext, "msg", CreateCmd("1"), "EVT", entity)
+            ).isValid()
+        )
+        assertTrue(
+            adapter.verifyTransition(
+                TransitionAppliedContext(automateContext, "msg", TestState.Created, DoCmd("1"), "EVT", entity)
+            ).isValid()
+        )
+    }
+
+    // ---- TransitionStateGuard ----
+
+    @Test
+    suspend fun `TransitionStateGuard accepts an available transition`() {
+        val guard = TransitionStateGuard<TestState, String, TestEntity, String, S2Automate>()
+        val entity = TestEntity("1", TestState.Created)
+        val result = guard.evaluateTransition(transitionContext(entity, DoCmd("1")))
+        assertTrue(result.isValid())
+    }
+
+    @Test
+    suspend fun `TransitionStateGuard rejects an unavailable transition`() {
+        val guard = TransitionStateGuard<TestState, String, TestEntity, String, S2Automate>()
+        val entity = TestEntity("1", TestState.Active)
+        val result = guard.evaluateTransition(transitionContext(entity, DoCmd("1")))
+        assertFalse(result.isValid())
+        assertEquals("ERROR_INVALID_TRANSITION", result.errors.single().type)
+    }
+
+    // ---- GuardVerifierImpl ----
+
+    private fun verifier(
+        publisher: RecordingPublisher,
+        guards: List<Guard<TestState, String, TestEntity, String, S2Automate>> = listOf(
+            TransitionStateGuard(),
+        ),
+    ) = GuardVerifierImpl(guards, automatePublisher(publisher))
+
+    @Test
+    suspend fun `evaluateInit passes when all guards accept`() {
+        val publisher = RecordingPublisher()
+        verifier(publisher).evaluateInit(InitTransitionContext(automateContext, CreateCmd("1")))
+        assertTrue(publisher.published.isEmpty())
+    }
+
+    @Test
+    suspend fun `evaluateTransition passes for a valid transition`() {
+        val publisher = RecordingPublisher()
+        val entity = TestEntity("1", TestState.Created)
+        verifier(publisher).evaluateTransition(transitionContext(entity, DoCmd("1")))
+        assertTrue(publisher.published.isEmpty())
+    }
+
+    @Test
+    suspend fun `evaluateTransition publishes not-accepted and throws for an invalid transition`() {
+        val publisher = RecordingPublisher()
+        val entity = TestEntity("1", TestState.Active)
+        val exception = assertThrows<AutomateException> {
+            verifier(publisher).evaluateTransition(transitionContext(entity, DoCmd("1")))
+        }
+        assertEquals("ERROR_INVALID_TRANSITION", exception.errors.single().type)
+        val event = publisher.published.single() as AutomateTransitionNotAccepted
+        assertEquals(TestState.Active, event.from)
+    }
+
+    @Test
+    suspend fun `verifyInitTransition returns the context when valid`() {
+        val publisher = RecordingPublisher()
+        val entity = TestEntity("1", TestState.Created)
+        val context = InitTransitionAppliedContext<TestState, String, TestEntity, String, S2Automate>(
+            automateContext, "msg", CreateCmd("1"), "EVT", entity
+        )
+        val returned = verifier(publisher).verifyInitTransition(context)
+        assertSame(context, returned)
+    }
+
+    @Test
+    suspend fun `verifyTransition aggregates errors from all guards`() {
+        val publisher = RecordingPublisher()
+        val failingGuard = object : GuardAdapter<TestState, String, TestEntity, String, S2Automate>() {
+            override suspend fun verifyTransition(
+                context: TransitionAppliedContext<TestState, String, TestEntity, String, S2Automate>
+            ) = GuardResult.error(s2error("E1", "one"), s2error("E2", "two"))
+        }
+        val entity = TestEntity("1", TestState.Created)
+        val context = TransitionAppliedContext<TestState, String, TestEntity, String, S2Automate>(
+            automateContext, "msg", TestState.Created, DoCmd("1"), "EVT", entity
+        )
+        val exception = assertThrows<AutomateException> {
+            verifier(publisher, listOf(failingGuard)).verifyTransition(context)
+        }
+        assertEquals(listOf("E1", "E2"), exception.errors.map { it.type })
+        assertEquals(1, publisher.published.size)
+    }
+
+    @Test
+    suspend fun `verifyTransition returns the context when valid`() {
+        val publisher = RecordingPublisher()
+        val entity = TestEntity("1", TestState.Created)
+        val context = TransitionAppliedContext<TestState, String, TestEntity, String, S2Automate>(
+            automateContext, "msg", TestState.Created, DoCmd("1"), "EVT", entity
+        )
+        val returned = verifier(publisher).verifyTransition(context)
+        assertSame(context, returned)
+        assertTrue(publisher.published.isEmpty())
+    }
+}

--- a/s2-automate/s2-automate-core/src/jvmTest/kotlin/s2/automate/core/sourcing/S2AutomateSourcingDeciderImplTest.kt
+++ b/s2-automate/s2-automate-core/src/jvmTest/kotlin/s2/automate/core/sourcing/S2AutomateSourcingDeciderImplTest.kt
@@ -1,0 +1,157 @@
+package s2.automate.core.sourcing
+
+import f2.dsl.cqrs.envelope.Envelope
+import f2.dsl.cqrs.enveloped.EnvelopedFlow
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.fold
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.toList
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import s2.automate.core.appevent.publisher.AppEventPublisher
+import s2.automate.core.engine.S2AutomateEngine
+import s2.dsl.automate.Evt
+import s2.dsl.automate.S2Command
+import s2.dsl.automate.S2InitCommand
+import s2.dsl.automate.S2State
+import s2.dsl.automate.model.WithS2Id
+import s2.dsl.automate.model.WithS2State
+import s2.sourcing.dsl.Loader
+import s2.sourcing.dsl.event.EventRepository
+
+class S2AutomateSourcingDeciderImplTest {
+
+    enum class TestState(override val position: Int) : S2State {
+        Created(0), Active(1)
+    }
+
+    data class TestEntity(val id: String, val state: TestState = TestState.Created) :
+        WithS2Id<String>, WithS2State<TestState> {
+        override fun s2Id(): String = id
+        override fun s2State(): TestState = state
+    }
+
+    sealed interface TestEvent : Evt, WithS2Id<String>
+    data class CreatedEvt(val id: String) : TestEvent {
+        override fun s2Id(): String = id
+    }
+
+    data class DoneEvt(val id: String) : TestEvent {
+        override fun s2Id(): String = id
+    }
+
+    data class CreateCmd(val id: String) : S2InitCommand
+    data class DoCmd(override val id: String) : S2Command<String>
+
+    private class StubEngine : S2AutomateEngine<TestState, TestEntity, String, TestEvent> {
+        override suspend fun <COMMAND : S2InitCommand, ENTITY_OUT : TestEntity, EVENT_OUT : TestEvent> create(
+            commands: EnvelopedFlow<COMMAND>,
+            decide: suspend (cmd: Envelope<COMMAND>) -> Pair<ENTITY_OUT, Envelope<EVENT_OUT>>
+        ): EnvelopedFlow<EVENT_OUT> = commands.map { command -> decide(command).second }
+
+        override suspend fun <COMMAND : S2Command<String>, ENTITY_OUT : TestEntity, EVENT_OUT : TestEvent>
+        doTransition(
+            commands: EnvelopedFlow<COMMAND>,
+            exec: suspend (Envelope<out COMMAND>, TestEntity) -> Pair<ENTITY_OUT, Envelope<EVENT_OUT>>
+        ): EnvelopedFlow<EVENT_OUT> = commands.map { command ->
+            exec(command, TestEntity(command.data.id)).second
+        }
+    }
+
+    private class RecordingPublisher : AppEventPublisher {
+        val published = mutableListOf<Any>()
+        override fun <EVENT> publish(event: EVENT & Any) {
+            published.add(event)
+        }
+    }
+
+    private class StubLoader : Loader<TestEvent, TestEntity, String> {
+        var reloadHistoryCalled = false
+        override suspend fun load(id: String): TestEntity? = TestEntity(id)
+        override suspend fun load(events: Flow<TestEvent>): TestEntity? = evolve(events)
+        override suspend fun loadAndEvolve(id: String, news: Flow<TestEvent>): TestEntity? =
+            evolve(news, TestEntity(id))
+
+        override suspend fun evolve(events: Flow<TestEvent>, entity: TestEntity?): TestEntity? =
+            events.fold(entity) { _, event -> TestEntity(event.s2Id()) }
+
+        override suspend fun reloadHistory(): List<TestEntity> {
+            reloadHistoryCalled = true
+            return listOf(TestEntity("history"))
+        }
+    }
+
+    private class StubEventRepository : EventRepository<TestEvent, String> {
+        val stored = mutableListOf<TestEvent>(CreatedEvt("stored"))
+        override suspend fun load(id: String): Flow<TestEvent> =
+            flowOf(*stored.filter { it.s2Id() == id }.toTypedArray())
+
+        override suspend fun loadAll(): Flow<TestEvent> = flowOf(*stored.toTypedArray())
+        override suspend fun persist(event: TestEvent): TestEvent = event.also(stored::add)
+        override suspend fun persist(events: Flow<TestEvent>): Flow<TestEvent> = events
+        override suspend fun createTable() { /* no-op for the stub */ }
+    }
+
+    private fun decider(
+        publisher: RecordingPublisher = RecordingPublisher(),
+        loader: StubLoader = StubLoader(),
+        eventStore: StubEventRepository = StubEventRepository(),
+    ) = S2AutomateSourcingDeciderImpl(StubEngine(), publisher, loader, eventStore)
+
+    @Test
+    suspend fun `init builds the event and publishes it`() {
+        val publisher = RecordingPublisher()
+        val decider = decider(publisher)
+        val event = decider.init(CreateCmd("1")) { CreatedEvt("1") }
+        assertEquals(CreatedEvt("1"), event)
+        assertEquals(listOf<Any>(CreatedEvt("1")), publisher.published)
+    }
+
+    @Test
+    suspend fun `transition executes against the loaded entity and publishes the event`() {
+        val publisher = RecordingPublisher()
+        val decider = decider(publisher)
+        val event = decider.transition(DoCmd("7")) { DoneEvt(s2Id()) }
+        assertEquals(DoneEvt("7"), event)
+        assertEquals(listOf<Any>(DoneEvt("7")), publisher.published)
+    }
+
+    @Test
+    suspend fun `decide flow overload maps every init command`() {
+        val decider = decider()
+        val events = decider.decide(flowOf(CreateCmd("1"), CreateCmd("2"))) { cmd -> CreatedEvt(cmd.id) }.toList()
+        assertEquals(listOf(CreatedEvt("1"), CreatedEvt("2")), events)
+    }
+
+    @Test
+    suspend fun `decide function overloads build reusable deciders`() {
+        val decider = decider()
+        val initDecide = decider.decide<CreatedEvt, CreateCmd> { cmd -> CreatedEvt(cmd.id) }
+        val created = initDecide(flowOf(CreateCmd("a"))).first()
+        assertEquals(CreatedEvt("a"), created)
+
+        val transitionDecide = decider.decide<DoCmd, DoneEvt> { cmd, entity -> DoneEvt(entity.s2Id() + cmd.id) }
+        val done = transitionDecide(flowOf(DoCmd("b"))).first()
+        assertEquals(DoneEvt("bb"), done)
+    }
+
+    @Test
+    suspend fun `loadAll and load delegate to the event store`() {
+        val eventStore = StubEventRepository()
+        val decider = decider(eventStore = eventStore)
+        assertEquals(listOf<TestEvent>(CreatedEvt("stored")), decider.loadAll().toList())
+        assertEquals(listOf<TestEvent>(CreatedEvt("stored")), decider.load("stored").toList())
+        assertTrue(decider.load("missing").toList().isEmpty())
+    }
+
+    @Test
+    suspend fun `replayHistory delegates to the projection loader`() {
+        val loader = StubLoader()
+        val decider = decider(loader = loader)
+        decider.replayHistory()
+        assertTrue(loader.reloadHistoryCalled)
+    }
+}

--- a/s2-automate/s2-automate-core/src/jvmTest/kotlin/s2/automate/core/storing/snap/SnapPersisterTest.kt
+++ b/s2-automate/s2-automate-core/src/jvmTest/kotlin/s2/automate/core/storing/snap/SnapPersisterTest.kt
@@ -83,7 +83,8 @@ class SnapPersisterTest {
 
     @Test
     suspend fun `persist routes through the retry task channel when configured`() {
-        val channel = RetryTaskChannel(maxAttempts = 2, delayMillis = 1, retryOn = IllegalStateException::class)
+        // Default maxAttempts/delayMillis on purpose: exercises the default-argument path.
+        val channel = RetryTaskChannel(retryOn = IllegalStateException::class)
         val persister = SnapPersister<TestState, String, TestEntity, TestEvent>(
             projectionLoader = StubLoader(),
             snapRepository = null,

--- a/s2-automate/s2-automate-core/src/jvmTest/kotlin/s2/automate/core/storing/snap/SnapPersisterTest.kt
+++ b/s2-automate/s2-automate-core/src/jvmTest/kotlin/s2/automate/core/storing/snap/SnapPersisterTest.kt
@@ -1,0 +1,110 @@
+package s2.automate.core.storing.snap
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.fold
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import s2.automate.core.error.AutomateException
+import s2.dsl.automate.Evt
+import s2.dsl.automate.S2State
+import s2.dsl.automate.model.WithS2Id
+import s2.dsl.automate.model.WithS2State
+import s2.sourcing.dsl.Loader
+import s2.sourcing.dsl.snap.SnapRepository
+
+class SnapPersisterTest {
+
+    enum class TestState(override val position: Int) : S2State {
+        Created(0)
+    }
+
+    data class TestEntity(val id: String, val state: TestState = TestState.Created) :
+        WithS2Id<String>, WithS2State<TestState> {
+        override fun s2Id(): String = id
+        override fun s2State(): TestState = state
+    }
+
+    data class TestEvent(val id: String) : Evt, WithS2Id<String> {
+        override fun s2Id(): String = id
+    }
+
+    private class StubLoader(
+        private val found: Boolean = true,
+    ) : Loader<TestEvent, TestEntity, String> {
+        override suspend fun load(id: String): TestEntity? = if (found) TestEntity(id) else null
+        override suspend fun load(events: Flow<TestEvent>): TestEntity? = evolve(events)
+        override suspend fun loadAndEvolve(id: String, news: Flow<TestEvent>): TestEntity? =
+            if (found) news.fold(TestEntity(id)) { entity, _ -> entity } else null
+
+        override suspend fun evolve(events: Flow<TestEvent>, entity: TestEntity?): TestEntity? =
+            events.fold(entity) { _, event -> TestEntity(event.s2Id()) }
+
+        override suspend fun reloadHistory(): List<TestEntity> = emptyList()
+    }
+
+    private class RecordingSnapRepository : SnapRepository<TestEntity, String> {
+        val saved = mutableListOf<TestEntity>()
+        override suspend fun get(id: String): TestEntity? = null
+        override suspend fun save(entity: TestEntity): TestEntity {
+            saved.add(entity)
+            return entity.copy(id = "saved-${entity.id}")
+        }
+
+        override suspend fun remove(id: String): Boolean = false
+    }
+
+    @Test
+    suspend fun `persist evolves the projection and saves the snapshot`() {
+        val snapRepository = RecordingSnapRepository()
+        val persister = SnapPersister<TestState, String, TestEntity, TestEvent>(
+            projectionLoader = StubLoader(),
+            snapRepository = snapRepository,
+            retryTaskChannel = null,
+        )
+        val (entity, event) = persister.persist(TestEvent("1"))
+        assertEquals("saved-1", entity.id)
+        assertEquals("1", event.id)
+        assertEquals(1, snapRepository.saved.size)
+    }
+
+    @Test
+    suspend fun `persist without snap repository returns the mutated entity`() {
+        val persister = SnapPersister<TestState, String, TestEntity, TestEvent>(
+            projectionLoader = StubLoader(),
+            snapRepository = null,
+            retryTaskChannel = null,
+        )
+        val (entity, _) = persister.persist(TestEvent("2"))
+        assertEquals("2", entity.id)
+    }
+
+    @Test
+    suspend fun `persist routes through the retry task channel when configured`() {
+        val channel = RetryTaskChannel(maxAttempts = 2, delayMillis = 1, retryOn = IllegalStateException::class)
+        val persister = SnapPersister<TestState, String, TestEntity, TestEvent>(
+            projectionLoader = StubLoader(),
+            snapRepository = null,
+            retryTaskChannel = channel,
+        )
+        val (entity, event) = persister.persist(TestEvent("3"))
+        assertEquals("3", entity.id)
+        assertEquals("3", event.id)
+        channel.cancelAllCoroutines()
+    }
+
+    @Test
+    suspend fun `persist throws when the projection cannot be loaded`() {
+        val persister = SnapPersister<TestState, String, TestEntity, TestEvent>(
+            projectionLoader = StubLoader(found = false),
+            snapRepository = null,
+            retryTaskChannel = null,
+        )
+        val exception = assertThrows<AutomateException> {
+            persister.persist(TestEvent("4"))
+        }
+        assertTrue(exception.errors.single().type == "ERROR_ENTITY_NOT_FOUND")
+    }
+}

--- a/s2-automate/s2-automate-dsl/src/commonMain/kotlin/s2/dsl/automate/model/WithS2Id.kt
+++ b/s2-automate/s2-automate-dsl/src/commonMain/kotlin/s2/dsl/automate/model/WithS2Id.kt
@@ -3,7 +3,7 @@ package s2.dsl.automate.model
 import kotlin.js.JsExport
 
 @JsExport
-interface WithS2Id<ID> {
+fun interface WithS2Id<ID> {
 	fun s2Id(): ID & Any
 }
 

--- a/s2-automate/s2-automate-dsl/src/commonMain/kotlin/s2/dsl/automate/model/WithS2State.kt
+++ b/s2-automate/s2-automate-dsl/src/commonMain/kotlin/s2/dsl/automate/model/WithS2State.kt
@@ -3,6 +3,6 @@ package s2.dsl.automate.model
 import kotlin.js.JsExport
 
 @JsExport
-interface WithS2State<STATE> {
+fun interface WithS2State<STATE> {
 	fun s2State(): STATE
 }

--- a/s2-automate/s2-automate-dsl/src/jvmTest/kotlin/s2/dsl/automate/S2ModelTest.kt
+++ b/s2-automate/s2-automate-dsl/src/jvmTest/kotlin/s2/dsl/automate/S2ModelTest.kt
@@ -1,0 +1,112 @@
+package s2.dsl.automate
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class S2ModelTest {
+
+    enum class TestState(override val position: Int) : S2State {
+        Created(0), Active(1)
+    }
+
+    data class DoCmd(override val id: String) : S2Command<String>
+
+    @Test
+    fun `s2error builds an S2ErrorBase with payload and cause`() {
+        val cause = IllegalStateException("boom")
+        val error = s2error(
+            code = "MY_ERROR",
+            description = "Something failed",
+            payload = mapOf("key" to "value"),
+            cause = cause,
+        )
+        assertThat(error.type).isEqualTo("MY_ERROR")
+        assertThat(error.description).isEqualTo("Something failed")
+        assertThat(error.date).isEmpty()
+        assertThat(error.payload).containsEntry("key", "value")
+        assertThat(error.cause).isSameAs(cause)
+    }
+
+    @Test
+    fun `s2error defaults payload and cause`() {
+        val error = s2error("CODE", "desc")
+        assertThat(error.payload).isEmpty()
+        assertThat(error.cause).isNull()
+    }
+
+    @Test
+    fun `s2warning builds an S2ErrorBase without cause`() {
+        val warning = s2warning("WARN", "careful", mapOf("a" to "b"))
+        assertThat(warning.type).isEqualTo("WARN")
+        assertThat(warning.description).isEqualTo("careful")
+        assertThat(warning.payload).containsEntry("a", "b")
+        assertThat(warning.cause).isNull()
+    }
+
+    @Test
+    fun `S2ErrorBase toString contains its fields`() {
+        val error = s2error("CODE", "desc", mapOf("k" to "v"))
+        assertThat(error.toString())
+            .contains("CODE")
+            .contains("desc")
+            .contains("k")
+    }
+
+    @Test
+    fun `S2EventSuccess carries id command and states`() {
+        val cmd = DoCmd("42")
+        val event = S2EventSuccess(id = "42", type = cmd, from = TestState.Created, to = TestState.Active)
+        assertThat(event.id).isEqualTo("42")
+        assertThat(event.type).isSameAs(cmd)
+        assertThat(event.from).isEqualTo(TestState.Created)
+        assertThat(event.to).isEqualTo(TestState.Active)
+    }
+
+    @Test
+    fun `S2EventError carries the error alongside the transition`() {
+        val cmd = DoCmd("42")
+        val error = s2error("ERR", "failed")
+        val event = S2EventError(id = "42", type = cmd, from = TestState.Created, to = TestState.Active, error = error)
+        assertThat(event.id).isEqualTo("42")
+        assertThat(event.error.type).isEqualTo("ERR")
+        assertThat(event.from).isEqualTo(TestState.Created)
+        assertThat(event.to).isEqualTo(TestState.Active)
+    }
+
+    @Test
+    fun `S2SubMachine defaults its flags`() {
+        val automate = S2Automate(name = "Sub", version = null, transitions = emptyArray())
+        val sub = S2SubMachine(automate = automate)
+        assertThat(sub.automate).isSameAs(automate)
+        assertThat(sub.startsOn).isEmpty()
+        assertThat(sub.endsOn).isEmpty()
+        assertThat(sub.autostart).isFalse()
+        assertThat(sub.blocking).isFalse()
+        assertThat(sub.singleton).isFalse()
+    }
+
+    @Test
+    fun `S2SubMachine accepts explicit configuration`() {
+        val automate = S2Automate(name = "Sub", version = "1", transitions = emptyArray())
+        val sub = S2SubMachine(
+            automate = automate,
+            startsOn = listOf(DoCmd::class),
+            endsOn = listOf(DoCmd::class),
+            autostart = true,
+            blocking = true,
+            singleton = true,
+        )
+        assertThat(sub.startsOn).containsExactly(DoCmd::class)
+        assertThat(sub.endsOn).containsExactly(DoCmd::class)
+        assertThat(sub.autostart).isTrue()
+        assertThat(sub.blocking).isTrue()
+        assertThat(sub.singleton).isTrue()
+    }
+
+    @Test
+    fun `ErrorCategory exposes the four retry categories`() {
+        assertThat(ErrorCategory.entries.map { it.name }).containsExactly(
+            "Rejected", "Transient", "Indeterminate", "Conflict",
+        )
+    }
+}

--- a/s2-automate/s2-automate-dsl/src/jvmTest/kotlin/s2/dsl/automate/builder/S2AutomateBuilderTest.kt
+++ b/s2-automate/s2-automate-dsl/src/jvmTest/kotlin/s2/dsl/automate/builder/S2AutomateBuilderTest.kt
@@ -1,0 +1,163 @@
+package s2.dsl.automate.builder
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import s2.dsl.automate.Evt
+import s2.dsl.automate.S2Command
+import s2.dsl.automate.S2InitCommand
+import s2.dsl.automate.S2Role
+import s2.dsl.automate.S2State
+
+class S2AutomateBuilderTest {
+
+    enum class OrderState(override val position: Int) : S2State {
+        Created(0), Approved(1), Closed(2)
+    }
+
+    object Admin : S2Role
+
+    data class CreateOrder(val value: String = "") : S2InitCommand
+    data class ApproveOrder(override val id: String) : S2Command<String>
+    data class UpdateOrder(override val id: String) : S2Command<String>
+    data class CloseOrder(override val id: String) : S2Command<String>
+    data class OrderCreated(val id: String) : Evt
+    data class OrderApproved(val id: String) : Evt
+
+    private val automate = s2 {
+        name = "Order"
+        version = "1.0.0"
+        init<CreateOrder> {
+            to = OrderState.Created
+            role = Admin
+            evt = OrderCreated::class
+        }
+        transaction<ApproveOrder> {
+            from = OrderState.Created
+            to = OrderState.Approved
+            role = Admin
+            evt = OrderApproved::class
+        }
+        selfTransaction<UpdateOrder> {
+            states += OrderState.Created
+            states += OrderState.Approved
+            role = Admin
+        }
+        node {
+            state = OrderState.Approved
+            transaction<CloseOrder> {
+                to = OrderState.Closed
+                role = Admin
+            }
+        }
+    }
+
+    @Test
+    fun `s2 builder registers name version and every transition flavor`() {
+        assertThat(automate.name).isEqualTo("Order")
+        assertThat(automate.version).isEqualTo("1.0.0")
+        // init + transaction + selfTransaction(2 states) + node = 5
+        assertThat(automate.transitions).hasSize(5)
+    }
+
+    @Test
+    fun `init transition has no from state and carries the event`() {
+        val init = automate.transitions.single { it.from == null }
+        assertThat(init.action.name).isEqualTo(CreateOrder::class.simpleName)
+        assertThat(init.result?.name).isEqualTo(OrderCreated::class.simpleName)
+        assertThat(init.to.position).isEqualTo(OrderState.Created.position)
+    }
+
+    @Test
+    fun `transaction with froms creates one transition per source state`() {
+        val multi = s2 {
+            name = "Multi"
+            transaction<ApproveOrder> {
+                froms += OrderState.Created
+                froms += OrderState.Closed
+                to = OrderState.Approved
+                role = Admin
+            }
+        }
+        assertThat(multi.transitions).hasSize(2)
+        assertThat(multi.transitions.map { it.from?.position })
+            .containsExactlyInAnyOrder(OrderState.Created.position, OrderState.Closed.position)
+        assertThat(multi.version).isNull()
+    }
+
+    @Test
+    fun `selfTransaction keeps the same from and to state`() {
+        val selfs = automate.transitions.filter { it.action.name == UpdateOrder::class.simpleName }
+        assertThat(selfs).hasSize(2)
+        selfs.forEach { assertThat(it.from?.position).isEqualTo(it.to.position) }
+    }
+
+    @Test
+    fun `node builder defaults to staying in the node state and supports explicit to`() {
+        val close = automate.transitions.single { it.action.name == CloseOrder::class.simpleName }
+        assertThat(close.from?.position).isEqualTo(OrderState.Approved.position)
+        assertThat(close.to.position).isEqualTo(OrderState.Closed.position)
+
+        val looping = s2 {
+            name = "Loop"
+            node {
+                state = OrderState.Created
+                transaction<UpdateOrder> {
+                    role = Admin
+                    evt = OrderApproved::class
+                }
+            }
+        }
+        val loop = looping.transitions.single()
+        assertThat(loop.from?.position).isEqualTo(OrderState.Created.position)
+        assertThat(loop.to.position).isEqualTo(OrderState.Created.position)
+        assertThat(loop.result?.name).isEqualTo(OrderApproved::class.simpleName)
+    }
+
+    @Test
+    fun `getAvailableTransitions returns transitions from the given state`() {
+        val actions = automate.getAvailableTransitions(OrderState.Created).map { it.action.name }
+        assertThat(actions).containsExactlyInAnyOrder(
+            ApproveOrder::class.simpleName,
+            UpdateOrder::class.simpleName,
+        )
+    }
+
+    @Test
+    fun `isAvailableTransition checks command against current state`() {
+        assertThat(automate.isAvailableTransition(OrderState.Created, ApproveOrder("1"))).isTrue()
+        assertThat(automate.isAvailableTransition(OrderState.Closed, ApproveOrder("1"))).isFalse()
+    }
+
+    @Test
+    fun `isAvailableInitTransition only accepts init commands`() {
+        assertThat(automate.isAvailableInitTransition(CreateOrder())).isTrue()
+        assertThat(automate.isAvailableInitTransition(ApproveOrder("1"))).isFalse()
+    }
+
+    @Test
+    fun `isFinalState is true when no transition leaves the state`() {
+        assertThat(automate.isFinalState(OrderState.Closed)).isTrue()
+        assertThat(automate.isFinalState(OrderState.Created)).isFalse()
+    }
+
+    @Test
+    fun `isSameState compares positions and handles null`() {
+        assertThat(automate.isSameState(OrderState.Created, OrderState.Created)).isTrue()
+        assertThat(automate.isSameState(OrderState.Created, OrderState.Approved)).isFalse()
+        assertThat(automate.isSameState(null, OrderState.Created)).isFalse()
+    }
+
+    @Test
+    fun `withResultAsAction is true only when every transition carries a result`() {
+        assertThat(automate.withResultAsAction).isFalse()
+        val allResults = s2 {
+            name = "AllResults"
+            init<CreateOrder> {
+                to = OrderState.Created
+                role = Admin
+                evt = OrderCreated::class
+            }
+        }
+        assertThat(allResults.withResultAsAction).isTrue()
+    }
+}

--- a/s2-automate/s2-automate-dsl/src/jvmTest/kotlin/s2/dsl/automate/builder/S2SourcingAutomateBuilderTest.kt
+++ b/s2-automate/s2-automate-dsl/src/jvmTest/kotlin/s2/dsl/automate/builder/S2SourcingAutomateBuilderTest.kt
@@ -1,0 +1,119 @@
+package s2.dsl.automate.builder
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import s2.dsl.automate.Evt
+import s2.dsl.automate.S2Command
+import s2.dsl.automate.S2InitCommand
+import s2.dsl.automate.S2Role
+import s2.dsl.automate.S2State
+
+class S2SourcingAutomateBuilderTest {
+
+    enum class DraftState(override val position: Int) : S2State {
+        Draft(0), Submitted(1), Validated(2)
+    }
+
+    object Issuer : S2Role
+
+    data class CreateDraft(val value: String = "") : S2InitCommand
+    data class SubmitDraft(override val id: String) : S2Command<String>
+    data class UpdateDraft(override val id: String) : S2Command<String>
+    data class ValidateDraft(override val id: String) : S2Command<String>
+    data class DraftCreated(val id: String) : Evt
+    data class DraftSubmitted(val id: String) : Evt
+    data class DraftUpdated(val id: String) : Evt
+    data class DraftValidated(val id: String) : Evt
+
+    private val automate = s2Sourcing {
+        name = "Draft"
+        init<CreateDraft, DraftCreated> {
+            to = DraftState.Draft
+            role = Issuer
+        }
+        transaction<SubmitDraft, DraftSubmitted> {
+            from = DraftState.Draft
+            to = DraftState.Submitted
+            role = Issuer
+            evt = DraftSubmitted::class
+        }
+        selfTransaction<UpdateDraft, DraftUpdated> {
+            states += DraftState.Draft
+            states += DraftState.Submitted
+            role = Issuer
+        }
+        node {
+            state = DraftState.Submitted
+            transaction<ValidateDraft> {
+                to = DraftState.Validated
+                role = Issuer
+                evt = DraftValidated::class
+            }
+        }
+    }
+
+    @Test
+    fun `s2Sourcing builder registers every transition flavor`() {
+        assertThat(automate.name).isEqualTo("Draft")
+        assertThat(automate.version).isNull()
+        // init + transaction + selfTransaction(2 states) + node = 5
+        assertThat(automate.transitions).hasSize(5)
+    }
+
+    @Test
+    fun `init defaults its result to the reified event type`() {
+        val init = automate.transitions.single { it.from == null }
+        assertThat(init.action.name).isEqualTo(CreateDraft::class.simpleName)
+        assertThat(init.result?.name).isEqualTo(DraftCreated::class.simpleName)
+    }
+
+    @Test
+    fun `selfTransaction defaults its result to the reified event type`() {
+        val selfs = automate.transitions.filter { it.action.name == UpdateDraft::class.simpleName }
+        assertThat(selfs).hasSize(2)
+        selfs.forEach {
+            assertThat(it.result?.name).isEqualTo(DraftUpdated::class.simpleName)
+            assertThat(it.from?.position).isEqualTo(it.to.position)
+        }
+    }
+
+    @Test
+    fun `transaction uses the explicit evt when provided`() {
+        val submit = automate.transitions.single { it.action.name == SubmitDraft::class.simpleName }
+        assertThat(submit.result?.name).isEqualTo(DraftSubmitted::class.simpleName)
+        assertThat(submit.from?.position).isEqualTo(DraftState.Draft.position)
+        assertThat(submit.to.position).isEqualTo(DraftState.Submitted.position)
+    }
+
+    @Test
+    fun `transaction with froms creates one transition per source state`() {
+        val multi = s2Sourcing {
+            name = "Multi"
+            transaction<ValidateDraft, DraftValidated> {
+                froms += DraftState.Draft
+                froms += DraftState.Submitted
+                to = DraftState.Validated
+                role = Issuer
+            }
+        }
+        assertThat(multi.transitions).hasSize(2)
+        // evt was not set explicitly: result stays null on the flow-transaction path
+        assertThat(multi.transitions.mapNotNull { it.result }).isEmpty()
+    }
+
+    @Test
+    fun `withResultAsAction reflects the sourcing defaults`() {
+        val sourcingOnly = s2Sourcing {
+            name = "Full"
+            init<CreateDraft, DraftCreated> {
+                to = DraftState.Draft
+                role = Issuer
+            }
+            selfTransaction<UpdateDraft, DraftUpdated> {
+                states += DraftState.Draft
+                role = Issuer
+            }
+        }
+        assertThat(sourcingOnly.withResultAsAction).isTrue()
+    }
+}

--- a/s2-automate/s2-automate-dsl/src/jvmTest/kotlin/s2/dsl/automate/extention/S2AutomateExtentionTest.kt
+++ b/s2-automate/s2-automate-dsl/src/jvmTest/kotlin/s2/dsl/automate/extention/S2AutomateExtentionTest.kt
@@ -1,0 +1,71 @@
+package s2.dsl.automate.extention
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import s2.dsl.automate.Evt
+import s2.dsl.automate.S2Command
+import s2.dsl.automate.S2InitCommand
+import s2.dsl.automate.S2Role
+import s2.dsl.automate.S2State
+import s2.dsl.automate.builder.s2
+import s2.dsl.automate.model.WithS2State
+
+class S2AutomateExtentionTest {
+
+    enum class OrderState(override val position: Int) : S2State {
+        Created(0), Approved(1)
+    }
+
+    object Admin : S2Role
+
+    data class CreateOrder(val value: String = "") : S2InitCommand
+    data class ApproveOrder(override val id: String) : S2Command<String>
+    data class OrderApproved(val id: String) : Evt
+
+    data class OrderEntity(val state: OrderState) : WithS2State<OrderState> {
+        override fun s2State(): OrderState = state
+    }
+
+    private val automate = s2 {
+        name = "Order"
+        init<CreateOrder> {
+            to = OrderState.Created
+            role = Admin
+        }
+        transaction<ApproveOrder> {
+            from = OrderState.Created
+            to = OrderState.Approved
+            role = Admin
+            evt = OrderApproved::class
+        }
+    }
+
+    @Test
+    fun `isAvailableTransition matches by action name`() {
+        assertThat(automate.isAvailableTransition(OrderState.Created, ApproveOrder::class.simpleName!!)).isTrue()
+        assertThat(automate.isAvailableTransition(OrderState.Approved, ApproveOrder::class.simpleName!!)).isFalse()
+    }
+
+    @Test
+    fun `isAvailableTransition matches by result event name`() {
+        assertThat(automate.isAvailableTransition(OrderState.Created, OrderApproved::class.simpleName!!)).isTrue()
+    }
+
+    @Test
+    fun `isAvailableTransition on model handles null model`() {
+        val model: WithS2State<OrderState>? = null
+        assertThat(automate.isAvailableTransition(model, ApproveOrder::class.simpleName!!)).isFalse()
+        assertThat(
+            automate.isAvailableTransition(OrderEntity(OrderState.Created), ApproveOrder::class.simpleName!!)
+        ).isTrue()
+    }
+
+    @Test
+    fun `canExecuteTransitionAnd combines transition availability and access`() {
+        val entity = OrderEntity(OrderState.Created)
+        assertThat(automate.canExecuteTransitionAnd<ApproveOrder>(entity) { true }).isTrue()
+        assertThat(automate.canExecuteTransitionAnd<ApproveOrder>(entity) { false }).isFalse()
+        val approved = OrderEntity(OrderState.Approved)
+        assertThat(automate.canExecuteTransitionAnd<ApproveOrder>(approved) { true }).isFalse()
+    }
+}

--- a/s2-event-sourcing/s2-event-sourcing-dsl/src/commonMain/kotlin/s2/sourcing/dsl/view/View.kt
+++ b/s2-event-sourcing/s2-event-sourcing-dsl/src/commonMain/kotlin/s2/sourcing/dsl/view/View.kt
@@ -2,7 +2,7 @@ package s2.sourcing.dsl.view
 
 import s2.dsl.automate.Evt
 
-interface View<EVENT, ENTITY>
+fun interface View<EVENT, ENTITY>
 where EVENT: Evt
 {
 	suspend fun evolve(event: EVENT, model: ENTITY?): ENTITY?

--- a/s2-event-sourcing/s2-event-sourcing-dsl/src/jvmTest/kotlin/s2/sourcing/dsl/snap/SnapLoaderTest.kt
+++ b/s2-event-sourcing/s2-event-sourcing-dsl/src/jvmTest/kotlin/s2/sourcing/dsl/snap/SnapLoaderTest.kt
@@ -1,0 +1,106 @@
+package s2.sourcing.dsl.snap
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import s2.dsl.automate.Evt
+import s2.dsl.automate.model.WithS2Id
+import s2.sourcing.dsl.event.EventRepository
+import s2.sourcing.dsl.view.View
+import s2.sourcing.dsl.view.ViewLoader
+
+class SnapLoaderTest {
+
+    data class TestEvent(val id: String, val value: Int) : Evt, WithS2Id<String> {
+        override fun s2Id(): String = id
+    }
+
+    data class TestEntity(val id: String, val total: Int) : WithS2Id<String> {
+        override fun s2Id(): String = id
+    }
+
+    private class StubEventRepository(
+        private val events: List<TestEvent>,
+    ) : EventRepository<TestEvent, String> {
+        override suspend fun load(id: String): Flow<TestEvent> =
+            flowOf(*events.filter { it.s2Id() == id }.toTypedArray())
+
+        override suspend fun loadAll(): Flow<TestEvent> = flowOf(*events.toTypedArray())
+        override suspend fun persist(event: TestEvent): TestEvent = event
+        override suspend fun persist(events: Flow<TestEvent>): Flow<TestEvent> = events
+        override suspend fun createTable() { /* no-op for the stub */ }
+    }
+
+    private val view = View<TestEvent, TestEntity> { event, model ->
+        TestEntity(event.s2Id(), (model?.total ?: 0) + event.value)
+    }
+
+    private class InMemorySnapRepository : SnapRepository<TestEntity, String> {
+        val store = mutableMapOf<String, TestEntity>()
+        val removed = mutableListOf<String>()
+        override suspend fun get(id: String): TestEntity? = store[id]
+        override suspend fun save(entity: TestEntity): TestEntity {
+            store[entity.s2Id()] = entity
+            return entity
+        }
+
+        override suspend fun remove(id: String): Boolean {
+            removed.add(id)
+            return store.remove(id) != null
+        }
+    }
+
+    private fun snapLoader(
+        snapRepository: InMemorySnapRepository = InMemorySnapRepository(),
+        events: List<TestEvent> = listOf(TestEvent("1", 10), TestEvent("2", 20)),
+    ): SnapLoader<TestEvent, TestEntity, String> {
+        val viewLoader = ViewLoader(StubEventRepository(events), view)
+        return SnapLoader(snapRepository, viewLoader)
+    }
+
+    @Test
+    suspend fun `load by id prefers the snapshot`() {
+        val snapRepository = InMemorySnapRepository()
+        snapRepository.save(TestEntity("1", 999))
+        val loader = snapLoader(snapRepository)
+        assertThat(loader.load("1")).isEqualTo(TestEntity("1", 999))
+    }
+
+    @Test
+    suspend fun `load by id falls back to the view loader on snapshot miss`() {
+        val loader = snapLoader()
+        assertThat(loader.load("1")).isEqualTo(TestEntity("1", 10))
+    }
+
+    @Test
+    suspend fun `loadAndEvolve applies news on top of the loaded entity`() {
+        val loader = snapLoader()
+        val entity = loader.loadAndEvolve("1", flowOf(TestEvent("1", 5)))
+        assertThat(entity).isEqualTo(TestEntity("1", 15))
+    }
+
+    @Test
+    suspend fun `load from events replays through the view`() {
+        val loader = snapLoader()
+        val entity = loader.load(flowOf(TestEvent("9", 1), TestEvent("9", 2)))
+        assertThat(entity).isEqualTo(TestEntity("9", 3))
+    }
+
+    @Test
+    suspend fun `evolve delegates to the view loader`() {
+        val loader = snapLoader()
+        val entity = loader.evolve(flowOf(TestEvent("1", 1)), TestEntity("1", 41))
+        assertThat(entity).isEqualTo(TestEntity("1", 42))
+    }
+
+    @Test
+    suspend fun `reloadHistory rebuilds entities and refreshes snapshots`() {
+        val snapRepository = InMemorySnapRepository()
+        val loader = snapLoader(snapRepository)
+        val entities = loader.reloadHistory()
+        assertThat(entities).containsExactlyInAnyOrder(TestEntity("1", 10), TestEntity("2", 20))
+        assertThat(snapRepository.store).hasSize(2)
+        assertThat(snapRepository.removed).containsExactlyInAnyOrder("1", "2")
+    }
+}

--- a/s2-event-sourcing/s2-event-sourcing-dsl/src/jvmTest/kotlin/s2/sourcing/dsl/view/SourcingViewExecutorImplTest.kt
+++ b/s2-event-sourcing/s2-event-sourcing-dsl/src/jvmTest/kotlin/s2/sourcing/dsl/view/SourcingViewExecutorImplTest.kt
@@ -1,0 +1,71 @@
+package s2.sourcing.dsl.view
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import s2.dsl.automate.Evt
+import s2.dsl.automate.model.WithS2Id
+import s2.sourcing.dsl.event.EventRepository
+import s2.sourcing.dsl.snap.SnapRepository
+
+class SourcingViewExecutorImplTest {
+
+    data class TestEvent(val id: String, val value: Int) : Evt, WithS2Id<String> {
+        override fun s2Id(): String = id
+    }
+
+    data class TestEntity(val id: String, val total: Int) : WithS2Id<String> {
+        override fun s2Id(): String = id
+    }
+
+    private class StubEventRepository : EventRepository<TestEvent, String> {
+        override suspend fun load(id: String): Flow<TestEvent> = flowOf(TestEvent(id, 10))
+        override suspend fun loadAll(): Flow<TestEvent> = flowOf()
+        override suspend fun persist(event: TestEvent): TestEvent = event
+        override suspend fun persist(events: Flow<TestEvent>): Flow<TestEvent> = events
+        override suspend fun createTable() { /* no-op for the stub */ }
+    }
+
+    private class RecordingView : View<TestEvent, TestEntity> {
+        val evolved = mutableListOf<Pair<TestEvent, TestEntity?>>()
+        override suspend fun evolve(event: TestEvent, model: TestEntity?): TestEntity {
+            evolved.add(event to model)
+            return TestEntity(event.s2Id(), (model?.total ?: 0) + event.value)
+        }
+    }
+
+    private class StubSnapRepository(
+        private val entity: TestEntity? = null,
+    ) : SnapRepository<TestEntity, String> {
+        override suspend fun get(id: String): TestEntity? = entity
+        override suspend fun save(entity: TestEntity): TestEntity = entity
+        override suspend fun remove(id: String): Boolean = false
+    }
+
+    @Test
+    suspend fun `evolve uses the snapshot when available`() {
+        val view = RecordingView()
+        val snapshot = TestEntity("1", 100)
+        val executor = SourcingViewExecutorImpl(
+            evolver = view,
+            viewBuilder = ViewLoader(StubEventRepository(), view),
+            viewRepository = StubSnapRepository(snapshot),
+        )
+        executor.evolve("1", TestEvent("1", 1))
+        assertThat(view.evolved.last().second).isEqualTo(snapshot)
+    }
+
+    @Test
+    suspend fun `evolve rebuilds the entity from events on snapshot miss`() {
+        val view = RecordingView()
+        val executor = SourcingViewExecutorImpl(
+            evolver = view,
+            viewBuilder = ViewLoader(StubEventRepository(), view),
+            viewRepository = StubSnapRepository(entity = null),
+        )
+        executor.evolve("1", TestEvent("1", 1))
+        // First evolve call comes from the ViewLoader rebuild, the last from the executor itself.
+        assertThat(view.evolved.last().second).isEqualTo(TestEntity("1", 10))
+    }
+}

--- a/s2-event-sourcing/s2-event-sourcing-dsl/src/jvmTest/kotlin/s2/sourcing/dsl/view/ViewLoaderLoadTest.kt
+++ b/s2-event-sourcing/s2-event-sourcing-dsl/src/jvmTest/kotlin/s2/sourcing/dsl/view/ViewLoaderLoadTest.kt
@@ -1,0 +1,59 @@
+package s2.sourcing.dsl.view
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import s2.dsl.automate.Evt
+import s2.dsl.automate.model.WithS2Id
+import s2.sourcing.dsl.event.EventRepository
+
+class ViewLoaderLoadTest {
+
+    data class TestEvent(val id: String, val value: Int) : Evt, WithS2Id<String> {
+        override fun s2Id(): String = id
+    }
+
+    data class TestEntity(val id: String, val total: Int)
+
+    private class StubEventRepository(
+        private val events: List<TestEvent>,
+    ) : EventRepository<TestEvent, String> {
+        override suspend fun load(id: String): Flow<TestEvent> =
+            flowOf(*events.filter { it.s2Id() == id }.toTypedArray())
+
+        override suspend fun loadAll(): Flow<TestEvent> = flowOf(*events.toTypedArray())
+        override suspend fun persist(event: TestEvent): TestEvent = event
+        override suspend fun persist(events: Flow<TestEvent>): Flow<TestEvent> = events
+        override suspend fun createTable() { /* no-op for the stub */ }
+    }
+
+    private val view = View<TestEvent, TestEntity> { event, model ->
+        TestEntity(event.s2Id(), (model?.total ?: 0) + event.value)
+    }
+
+    private fun loader(events: List<TestEvent> = listOf(TestEvent("1", 1), TestEvent("1", 2))) =
+        ViewLoader(StubEventRepository(events), view)
+
+    @Test
+    suspend fun `load by id folds all events of the entity`() {
+        assertThat(loader().load("1")).isEqualTo(TestEntity("1", 3))
+    }
+
+    @Test
+    suspend fun `load by id returns null when there is no event`() {
+        assertThat(loader().load("missing")).isNull()
+    }
+
+    @Test
+    suspend fun `loadAndEvolve folds history then the news`() {
+        val entity = loader().loadAndEvolve("1", flowOf(TestEvent("1", 4)))
+        assertThat(entity).isEqualTo(TestEntity("1", 7))
+    }
+
+    @Test
+    suspend fun `evolve starts from the provided entity`() {
+        val entity = loader().evolve(flowOf(TestEvent("1", 1)), TestEntity("1", 10))
+        assertThat(entity).isEqualTo(TestEntity("1", 11))
+    }
+}

--- a/s2-spring/sourcing/s2-spring-boot-starter-sourcing-data-mongodb/src/main/kotlin/s2/spring/sourcing/data/mongodb/MongoEventRepository.kt
+++ b/s2-spring/sourcing/s2-spring-boot-starter-sourcing-data-mongodb/src/main/kotlin/s2/spring/sourcing/data/mongodb/MongoEventRepository.kt
@@ -12,6 +12,8 @@ import s2.dsl.automate.model.WithS2Id
 import s2.sourcing.dsl.event.EventRepository
 import s2.spring.sourcing.data.event.EventSourcing
 
+// S6309: the suspend modifier is mandated by the EventRepository contract (published API).
+@Suppress("kotlin:S6309")
 class MongoEventRepository<EVENT, ID>(
 	private val json: Json,
 	private val eventRepository: SpringDataEventRepository<EVENT, ID>,

--- a/s2-spring/sourcing/s2-spring-boot-starter-sourcing-data-mongodb/src/main/kotlin/s2/spring/sourcing/data/mongodb/MongoEventRepositoryFactory.kt
+++ b/s2-spring/sourcing/s2-spring-boot-starter-sourcing-data-mongodb/src/main/kotlin/s2/spring/sourcing/data/mongodb/MongoEventRepositoryFactory.kt
@@ -19,6 +19,9 @@ class MongoEventRepositoryFactory(
     ): EventRepository<EVENT, ID> where EVENT : Evt, EVENT : WithS2Id<ID> {
         val repositoryFactorySupport = ReactiveMongoRepositoryFactory(mongoOperations)
         val repository = repositoryFactorySupport.getRepository(SpringDataEventRepository::class.java)
+        // The Spring repository factory API is not generic-aware: the cast is required and safe
+        // because SpringDataEventRepository is only ever parameterized with the requested types.
+        @Suppress("UNCHECKED_CAST", "kotlin:S6530")
         return MongoEventRepository(json, repository as SpringDataEventRepository<EVENT, ID>, eventType)
     }
 }

--- a/s2-spring/sourcing/s2-spring-boot-starter-sourcing-data-mongodb/src/main/kotlin/s2/spring/sourcing/data/mongodb/SpringDataEventRepository.kt
+++ b/s2-spring/sourcing/s2-spring-boot-starter-sourcing-data-mongodb/src/main/kotlin/s2/spring/sourcing/data/mongodb/SpringDataEventRepository.kt
@@ -7,5 +7,5 @@ import s2.spring.sourcing.data.event.EventSourcing
 
 @Repository
 interface SpringDataEventRepository<EVENT, ID>: CoroutineCrudRepository<EventSourcing<ID>, String> {
-	suspend fun findAllByObjId(objId: ID) : Flow<EventSourcing<ID>>
+	fun findAllByObjId(objId: ID) : Flow<EventSourcing<ID>>
 }

--- a/s2-spring/sourcing/s2-spring-boot-starter-sourcing-data-r2dbc/build.gradle.kts
+++ b/s2-spring/sourcing/s2-spring-boot-starter-sourcing-data-r2dbc/build.gradle.kts
@@ -10,12 +10,12 @@ dependencies {
 	implementation(libs.kotlinx.serialization.json)
 	implementation(libs.kotlinx.coroutines.reactive)
 	implementation(libs.kotlinx.coroutines.reactor)
+	runtimeOnly(libs.postgresql)
+	runtimeOnly(libs.r2dbc.postgresql)
 
 	// Test dependencies
 	testImplementation(libs.bundles.testcontainers)
 	testImplementation(libs.bundles.testcontainers.postgres)
-	runtimeOnly(libs.postgresql)
-	runtimeOnly(libs.r2dbc.postgresql)
 	testImplementation(libs.spring.boot.starter.test)
 	testImplementation(libs.bundles.test.junit)
 }

--- a/s2-spring/sourcing/s2-spring-boot-starter-sourcing-data-r2dbc/src/main/kotlin/s2/spring/sourcing/data/r2dbc/R2dbcEventRepository.kt
+++ b/s2-spring/sourcing/s2-spring-boot-starter-sourcing-data-r2dbc/src/main/kotlin/s2/spring/sourcing/data/r2dbc/R2dbcEventRepository.kt
@@ -21,6 +21,8 @@ import s2.dsl.automate.model.WithS2Id
 import s2.sourcing.dsl.event.EventRepository
 import s2.spring.sourcing.data.event.EventSourcing
 
+// S6309: the suspend modifier is mandated by the EventRepository contract (published API).
+@Suppress("kotlin:S6309")
 class R2dbcEventRepository<EVENT, ID>(
 	private val json: Json,
 	private val databaseClient: DatabaseClient,

--- a/s2-spring/sourcing/s2-spring-boot-starter-sourcing-data/src/main/kotlin/s2/spring/sourcing/data/event/EventSourcing.kt
+++ b/s2-spring/sourcing/s2-spring-boot-starter-sourcing-data/src/main/kotlin/s2/spring/sourcing/data/event/EventSourcing.kt
@@ -4,8 +4,6 @@ import jakarta.persistence.Entity
 import jakarta.persistence.EntityListeners
 import jakarta.persistence.Id
 import jakarta.persistence.MappedSuperclass
-import jakarta.persistence.Temporal
-import jakarta.persistence.TemporalType
 import java.time.LocalDateTime
 import org.springframework.data.annotation.CreatedBy
 import org.springframework.data.annotation.CreatedDate
@@ -24,12 +22,10 @@ class EventSourcing<ID>(
 	@CreatedBy
 	var createdBy: String? = null,
 	@CreatedDate
-	@Temporal(TemporalType.TIMESTAMP)
 	var createdDate: LocalDateTime? = null,
 	@LastModifiedBy
 	var lastModifiedBy: String? = null,
 	@LastModifiedDate
-	@Temporal(TemporalType.TIMESTAMP)
 	var lastModifiedDate: LocalDateTime? = null,
 	@Version
 	var version: Int? = null,

--- a/s2-spring/sourcing/s2-spring-boot-starter-sourcing/src/main/kotlin/s2/spring/automate/sourcing/S2AutomateDeciderSpring.kt
+++ b/s2-spring/sourcing/s2-spring-boot-starter-sourcing/src/main/kotlin/s2/spring/automate/sourcing/S2AutomateDeciderSpring.kt
@@ -14,6 +14,9 @@ import s2.sourcing.dsl.Decide
 import s2.sourcing.dsl.Loader
 import s2.sourcing.dsl.event.EventRepository
 
+// S6309: the suspend modifier is mandated by the S2AutomateSourcingDecider contract (published API).
+// S6514: interface delegation with "by" is impossible, the engine is injected after construction.
+@Suppress("kotlin:S6309", "kotlin:S6514")
 open class S2AutomateDeciderSpring<ENTITY, STATE, EVENT, ID> : S2AutomateSourcingDecider<ENTITY, STATE, EVENT, ID> where
 STATE : S2State,
 EVENT : Evt,

--- a/s2-spring/sourcing/s2-spring-boot-starter-sourcing/src/main/kotlin/s2/spring/automate/sourcing/persist/S2AutomateSourcingPersister.kt
+++ b/s2-spring/sourcing/s2-spring-boot-starter-sourcing/src/main/kotlin/s2/spring/automate/sourcing/persist/S2AutomateSourcingPersister.kt
@@ -17,6 +17,8 @@ import s2.dsl.automate.model.WithS2State
 import s2.sourcing.dsl.Loader
 import s2.sourcing.dsl.event.EventRepository
 
+// S6309: the suspend modifier is mandated by the AutomatePersister contract (published API).
+@Suppress("kotlin:S6309")
 class S2AutomateSourcingPersister<STATE, ID, ENTITY, EVENT>(
     private val projectionLoader: Loader<EVENT, ENTITY, ID>,
     private val eventStore: EventRepository<EVENT, ID>,
@@ -33,7 +35,6 @@ EVENT: WithS2Id<ID> {
     }
 
     override suspend fun load(automateContexts: AutomateContext<S2Automate>, ids: Flow<ID & Any>): Flow<ENTITY?> {
-        // TODO Fix to do here
         return ids.map { id ->
             projectionLoader.load(id)
         }

--- a/s2-spring/storing/s2-spring-boot-starter-storing-data/build.gradle.kts
+++ b/s2-spring/storing/s2-spring-boot-starter-storing-data/build.gradle.kts
@@ -11,4 +11,6 @@ dependencies {
 	implementation(libs.bundles.spring.data.commons)
 	implementation(libs.kotlinx.coroutines.reactive)
 	implementation(libs.kotlinx.coroutines.reactor)
+
+	testImplementation(libs.bundles.test.junit)
 }

--- a/s2-spring/storing/s2-spring-boot-starter-storing-data/src/main/kotlin/s2/spring/automate/data/persister/SpringDataAutomateCoroutinePersisterFlow.kt
+++ b/s2-spring/storing/s2-spring-boot-starter-storing-data/src/main/kotlin/s2/spring/automate/data/persister/SpringDataAutomateCoroutinePersisterFlow.kt
@@ -2,6 +2,7 @@ package s2.spring.automate.data.persister
 
 import f2.dsl.fnc.operators.batch
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
@@ -17,6 +18,8 @@ import s2.dsl.automate.S2State
 import s2.dsl.automate.model.WithS2Id
 import s2.dsl.automate.model.WithS2State
 
+// S6309: the suspend modifier is mandated by the AutomatePersister contract (published API).
+@Suppress("kotlin:S6309")
 class SpringDataAutomateCoroutinePersisterFlow<STATE, ID: Any, ENTITY, EVENT>(
 	private val repository: CoroutineCrudRepository<ENTITY, ID>,
 	private val batchParams: S2BatchProperties,
@@ -41,7 +44,7 @@ ENTITY : WithS2Id<ID> {
 		return transitionContexts.batch(batchParams.asBatch()) { context ->
 			val entities = context.map { it.entity }
 			val events = context.map { it.event }
-			repository.saveAll(entities)
+			repository.saveAll(entities).collect()
 			events
 		}
 	}
@@ -57,7 +60,7 @@ ENTITY : WithS2Id<ID> {
 			events.add(context.event)
 		}
 
-		repository.saveAll(entities)
+		repository.saveAll(entities).collect()
 
 		events.forEach { event ->
 			emit(event)

--- a/s2-spring/storing/s2-spring-boot-starter-storing-data/src/main/kotlin/s2/spring/automate/data/persister/SpringDataAutomatePersisterFlow.kt
+++ b/s2-spring/storing/s2-spring-boot-starter-storing-data/src/main/kotlin/s2/spring/automate/data/persister/SpringDataAutomatePersisterFlow.kt
@@ -16,6 +16,8 @@ import s2.dsl.automate.S2State
 import s2.dsl.automate.model.WithS2Id
 import s2.dsl.automate.model.WithS2State
 
+// S6309: the suspend modifier is mandated by the AutomatePersister contract (published API).
+@Suppress("kotlin:S6309")
 class SpringDataAutomatePersisterFlow<STATE, ID: Any, ENTITY, EVENT>(
 	private val repository: CrudRepository<ENTITY, ID>,
 ) : AutomatePersister<STATE, ID, ENTITY, EVENT, S2Automate> where

--- a/s2-spring/storing/s2-spring-boot-starter-storing-data/src/main/kotlin/s2/spring/automate/data/persister/SpringDataAutomateReactivePersisterFlow.kt
+++ b/s2-spring/storing/s2-spring-boot-starter-storing-data/src/main/kotlin/s2/spring/automate/data/persister/SpringDataAutomateReactivePersisterFlow.kt
@@ -2,6 +2,7 @@ package s2.spring.automate.data.persister
 
 import f2.dsl.fnc.operators.batch
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.reactive.asFlow
@@ -19,6 +20,8 @@ import s2.dsl.automate.S2State
 import s2.dsl.automate.model.WithS2Id
 import s2.dsl.automate.model.WithS2State
 
+// S6309: the suspend modifier is mandated by the AutomatePersister contract (published API).
+@Suppress("kotlin:S6309")
 class SpringDataAutomateReactivePersisterFlow<STATE, ID: Any, ENTITY, EVENT>(
 	private val repository: ReactiveCrudRepository<ENTITY, ID>,
 	private val batchParams: S2BatchProperties,
@@ -43,7 +46,7 @@ ENTITY : WithS2Id<ID> {
 		return transitionContexts.batch(batchParams.asBatch()) { contexts ->
 			val entities = contexts.map { it.entity }
 			val events = contexts.map { it.event }
-			repository.saveAll(entities)
+			repository.saveAll(entities).asFlow().collect()
 			events
 		}
 	}
@@ -53,7 +56,7 @@ ENTITY : WithS2Id<ID> {
 		return transitionContexts.batch(batchParams.asBatch()) { contexts ->
 			val entities = contexts.map { it.entity }
 			val events = contexts.map { it.event }
-			repository.saveAll(entities)
+			repository.saveAll(entities).asFlow().collect()
 			events
 		}
 	}

--- a/s2-spring/storing/s2-spring-boot-starter-storing-data/src/test/kotlin/s2/spring/automate/data/persister/SpringDataPersisterFlowTest.kt
+++ b/s2-spring/storing/s2-spring-boot-starter-storing-data/src/test/kotlin/s2/spring/automate/data/persister/SpringDataPersisterFlowTest.kt
@@ -1,0 +1,250 @@
+package s2.spring.automate.data.persister
+
+import java.util.Optional
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.toList
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.reactivestreams.Publisher
+import org.springframework.data.repository.CrudRepository
+import org.springframework.data.repository.kotlin.CoroutineCrudRepository
+import org.springframework.data.repository.reactive.ReactiveCrudRepository
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
+import s2.automate.core.config.S2BatchProperties
+import s2.automate.core.context.AutomateContext
+import s2.automate.core.context.InitTransitionAppliedContext
+import s2.automate.core.context.TransitionAppliedContext
+import s2.dsl.automate.Evt
+import s2.dsl.automate.S2Automate
+import s2.dsl.automate.S2Command
+import s2.dsl.automate.S2InitCommand
+import s2.dsl.automate.S2State
+import s2.dsl.automate.model.WithS2Id
+import s2.dsl.automate.model.WithS2State
+
+class SpringDataPersisterFlowTest {
+
+    enum class TestState(override val position: Int) : S2State {
+        Created(0)
+    }
+
+    data class TestEntity(val id: String, val state: TestState = TestState.Created) :
+        WithS2Id<String>, WithS2State<TestState> {
+        override fun s2Id(): String = id
+        override fun s2State(): TestState = state
+    }
+
+    data class TestEvent(val id: String) : Evt
+
+    data class CreateCmd(val id: String) : S2InitCommand
+    data class DoCmd(override val id: String) : S2Command<String>
+
+    private val automate = S2Automate(name = "PersisterTest", version = null, transitions = emptyArray())
+    private val automateContext = AutomateContext(automate, S2BatchProperties(size = 2))
+
+    private fun initContext(id: String) =
+        InitTransitionAppliedContext<TestState, String, TestEntity, TestEvent, S2Automate>(
+            automateContext = automateContext,
+            msgId = "msg-$id",
+            msg = CreateCmd(id),
+            event = TestEvent(id),
+            entity = TestEntity(id),
+        )
+
+    private fun transitionContext(id: String) =
+        TransitionAppliedContext<TestState, String, TestEntity, TestEvent, S2Automate>(
+            automateContext = automateContext,
+            msgId = "msg-$id",
+            from = TestState.Created,
+            msg = DoCmd(id),
+            event = TestEvent(id),
+            entity = TestEntity(id),
+        )
+
+    // ---- coroutine repository ----
+
+    private class InMemoryCoroutineRepository(
+        initial: Map<String, TestEntity> = emptyMap(),
+    ) : CoroutineCrudRepository<TestEntity, String> {
+        val store = initial.toMutableMap()
+        override suspend fun <S : TestEntity> save(entity: S): TestEntity {
+            store[entity.s2Id()] = entity
+            return entity
+        }
+
+        override fun <S : TestEntity> saveAll(entities: Iterable<S>): Flow<S> {
+            entities.forEach { store[it.s2Id()] = it }
+            return entities.toList().asFlow()
+        }
+
+        override fun <S : TestEntity> saveAll(entityStream: Flow<S>): Flow<S> = entityStream
+        override suspend fun findById(id: String): TestEntity? = store[id]
+        override suspend fun existsById(id: String): Boolean = store.containsKey(id)
+        override fun findAll(): Flow<TestEntity> = store.values.toList().asFlow()
+        override fun findAllById(ids: Iterable<String>): Flow<TestEntity> =
+            ids.mapNotNull { store[it] }.asFlow()
+
+        override fun findAllById(ids: Flow<String>): Flow<TestEntity> =
+            store.values.toList().asFlow()
+
+        override suspend fun count(): Long = store.size.toLong()
+        override suspend fun deleteById(id: String) = Unit
+        override suspend fun delete(entity: TestEntity) = Unit
+        override suspend fun deleteAllById(ids: Iterable<String>) = Unit
+        override suspend fun deleteAll(entities: Iterable<TestEntity>) = Unit
+        override suspend fun <S : TestEntity> deleteAll(entityStream: Flow<S>) = Unit
+        override suspend fun deleteAll() = Unit
+    }
+
+    @Test
+    suspend fun `coroutine persister saves entities and emits events on persistInit`() {
+        val repository = InMemoryCoroutineRepository()
+        val persister = SpringDataAutomateCoroutinePersisterFlow<TestState, String, TestEntity, TestEvent>(
+            repository, S2BatchProperties(size = 2),
+        )
+        val events = persister.persistInit(flowOf(initContext("1"), initContext("2"), initContext("3"))).toList()
+        assertThat(events.map { it.id }).containsExactly("1", "2", "3")
+        assertThat(repository.store.keys).containsExactlyInAnyOrder("1", "2", "3")
+    }
+
+    @Test
+    suspend fun `coroutine persister saves entities and emits events on persist`() {
+        val repository = InMemoryCoroutineRepository()
+        val persister = SpringDataAutomateCoroutinePersisterFlow<TestState, String, TestEntity, TestEvent>(
+            repository, S2BatchProperties(size = 2),
+        )
+        val events = persister.persist(flowOf(transitionContext("1"), transitionContext("2"))).toList()
+        assertThat(events.map { it.id }).containsExactly("1", "2")
+        assertThat(repository.store.keys).containsExactlyInAnyOrder("1", "2")
+    }
+
+    @Test
+    suspend fun `coroutine persister loads by id and by ids`() {
+        val repository = InMemoryCoroutineRepository(mapOf("1" to TestEntity("1")))
+        val persister = SpringDataAutomateCoroutinePersisterFlow<TestState, String, TestEntity, TestEvent>(
+            repository, S2BatchProperties(),
+        )
+        assertThat(persister.load(automateContext, "1")).isEqualTo(TestEntity("1"))
+        assertThat(persister.load(automateContext, flowOf("1")).toList()).containsExactly(TestEntity("1"))
+    }
+
+    // ---- blocking repository ----
+
+    private class InMemoryBlockingRepository(
+        initial: Map<String, TestEntity> = emptyMap(),
+    ) : CrudRepository<TestEntity, String> {
+        val store = initial.toMutableMap()
+        override fun <S : TestEntity> save(entity: S): S {
+            store[entity.s2Id()] = entity
+            return entity
+        }
+
+        override fun <S : TestEntity> saveAll(entities: Iterable<S>): Iterable<S> {
+            entities.forEach { store[it.s2Id()] = it }
+            return entities
+        }
+
+        override fun findById(id: String): Optional<TestEntity> = Optional.ofNullable(store[id])
+        override fun existsById(id: String): Boolean = store.containsKey(id)
+        override fun findAll(): Iterable<TestEntity> = store.values
+        override fun findAllById(ids: Iterable<String>): Iterable<TestEntity> = ids.mapNotNull { store[it] }
+        override fun count(): Long = store.size.toLong()
+        override fun deleteById(id: String) = Unit
+        override fun delete(entity: TestEntity) = Unit
+        override fun deleteAllById(ids: Iterable<String>) = Unit
+        override fun deleteAll(entities: Iterable<TestEntity>) = Unit
+        override fun deleteAll() = Unit
+    }
+
+    @Test
+    suspend fun `blocking persister saves entities and emits events`() {
+        val repository = InMemoryBlockingRepository()
+        val persister = SpringDataAutomatePersisterFlow<TestState, String, TestEntity, TestEvent>(repository)
+        val initEvents = persister.persistInit(flowOf(initContext("1"))).toList()
+        assertThat(initEvents.map { it.id }).containsExactly("1")
+        val events = persister.persist(flowOf(transitionContext("2"))).toList()
+        assertThat(events.map { it.id }).containsExactly("2")
+        assertThat(repository.store.keys).containsExactlyInAnyOrder("1", "2")
+    }
+
+    @Test
+    suspend fun `blocking persister loads by id and by ids`() {
+        val repository = InMemoryBlockingRepository(mapOf("1" to TestEntity("1")))
+        val persister = SpringDataAutomatePersisterFlow<TestState, String, TestEntity, TestEvent>(repository)
+        assertThat(persister.load(automateContext, "1")).isEqualTo(TestEntity("1"))
+        assertThat(persister.load(automateContext, flowOf("1")).toList()).containsExactly(TestEntity("1"))
+    }
+
+    // ---- reactive repository ----
+
+    private class InMemoryReactiveRepository(
+        initial: Map<String, TestEntity> = emptyMap(),
+    ) : ReactiveCrudRepository<TestEntity, String> {
+        val store = initial.toMutableMap()
+        override fun <S : TestEntity> save(entity: S): Mono<S> {
+            store[entity.s2Id()] = entity
+            return Mono.just(entity)
+        }
+
+        override fun <S : TestEntity> saveAll(entities: Iterable<S>): Flux<S> {
+            entities.forEach { store[it.s2Id()] = it }
+            return Flux.fromIterable(entities)
+        }
+
+        override fun <S : TestEntity> saveAll(entityStream: Publisher<S>): Flux<S> = Flux.from(entityStream)
+        override fun findById(id: String): Mono<TestEntity> = Mono.justOrEmpty(store[id])
+        override fun findById(id: Publisher<String>): Mono<TestEntity> = Mono.from(id).flatMap { findById(it) }
+        override fun existsById(id: String): Mono<Boolean> = Mono.just(store.containsKey(id))
+        override fun existsById(id: Publisher<String>): Mono<Boolean> = Mono.from(id).flatMap { existsById(it) }
+        override fun findAll(): Flux<TestEntity> = Flux.fromIterable(store.values)
+        override fun findAllById(ids: Iterable<String>): Flux<TestEntity> =
+            Flux.fromIterable(ids.mapNotNull { store[it] })
+
+        override fun findAllById(idStream: Publisher<String>): Flux<TestEntity> =
+            Flux.from(idStream).mapNotNull { store[it] }
+
+        override fun count(): Mono<Long> = Mono.just(store.size.toLong())
+        override fun deleteById(id: String): Mono<Void> = Mono.empty()
+        override fun deleteById(id: Publisher<String>): Mono<Void> = Mono.empty()
+        override fun delete(entity: TestEntity): Mono<Void> = Mono.empty()
+        override fun deleteAllById(ids: Iterable<String>): Mono<Void> = Mono.empty()
+        override fun deleteAll(entities: Iterable<TestEntity>): Mono<Void> = Mono.empty()
+        override fun deleteAll(entityStream: Publisher<out TestEntity>): Mono<Void> = Mono.empty()
+        override fun deleteAll(): Mono<Void> = Mono.empty()
+    }
+
+    @Test
+    suspend fun `reactive persister saves entities and emits events on persistInit`() {
+        val repository = InMemoryReactiveRepository()
+        val persister = SpringDataAutomateReactivePersisterFlow<TestState, String, TestEntity, TestEvent>(
+            repository, S2BatchProperties(size = 2),
+        )
+        val events = persister.persistInit(flowOf(initContext("1"), initContext("2"), initContext("3"))).toList()
+        assertThat(events.map { it.id }).containsExactly("1", "2", "3")
+        assertThat(repository.store.keys).containsExactlyInAnyOrder("1", "2", "3")
+    }
+
+    @Test
+    suspend fun `reactive persister saves entities and emits events on persist`() {
+        val repository = InMemoryReactiveRepository()
+        val persister = SpringDataAutomateReactivePersisterFlow<TestState, String, TestEntity, TestEvent>(
+            repository, S2BatchProperties(size = 2),
+        )
+        val events = persister.persist(flowOf(transitionContext("1"), transitionContext("2"))).toList()
+        assertThat(events.map { it.id }).containsExactly("1", "2")
+        assertThat(repository.store.keys).containsExactlyInAnyOrder("1", "2")
+    }
+
+    @Test
+    suspend fun `reactive persister loads by id and by ids`() {
+        val repository = InMemoryReactiveRepository(mapOf("1" to TestEntity("1")))
+        val persister = SpringDataAutomateReactivePersisterFlow<TestState, String, TestEntity, TestEvent>(
+            repository, S2BatchProperties(),
+        )
+        assertThat(persister.load(automateContext, "1")).isEqualTo(TestEntity("1"))
+        assertThat(persister.load(automateContext, flowOf("1")).toList()).containsExactly(TestEntity("1"))
+    }
+}

--- a/s2-spring/storing/s2-spring-boot-starter-storing/src/main/kotlin/s2/spring/automate/executor/S2AutomateExecutorSpring.kt
+++ b/s2-spring/storing/s2-spring-boot-starter-storing/src/main/kotlin/s2/spring/automate/executor/S2AutomateExecutorSpring.kt
@@ -28,6 +28,9 @@ import s2.sourcing.dsl.Decide
  * @param ID The identifier type of the entity.
  * @param ENTITY The entity type.
  */
+// S6309: the suspend modifier is mandated by the S2AutomateStoringEvolver contracts (published API).
+// S6514: interface delegation with "by" is impossible, the engine is injected after construction.
+@Suppress("kotlin:S6309", "kotlin:S6514")
 open class S2AutomateExecutorSpring<STATE, ID, ENTITY> :
     S2AutomateStoringEvolver<STATE, ID, ENTITY, Evt>,
     S2AutomateStoringEvolverFlow<STATE, ID, ENTITY, Evt>

--- a/s2-test/s2-test-bdd/src/main/kotlin/s2/bdd/step/exceptions/NotFoundExceptionAssertionSteps.kt
+++ b/s2-test/s2-test-bdd/src/main/kotlin/s2/bdd/step/exceptions/NotFoundExceptionAssertionSteps.kt
@@ -13,8 +13,9 @@ class NotFoundExceptionAssertionSteps: En, S2CucumberStepsDefinition() {
         DataTableType(::notFoundParams)
 
         Then("The {string} should not be found") { objectName: String ->
-            val lastUsedKey = context.entityLists[objectName]!!.lastUsedKey
-            assert(lastUsedKey.toString())
+            val entityList = context.entityLists[objectName]
+                ?: error("No entity list registered for \"$objectName\"")
+            assert(entityList.lastUsedKey.toString())
         }
 
     }

--- a/s2-test/s2-test-bdd/src/main/kotlin/s2/bdd/step/exceptions/NotFoundExceptionAssertionSteps.kt
+++ b/s2-test/s2-test-bdd/src/main/kotlin/s2/bdd/step/exceptions/NotFoundExceptionAssertionSteps.kt
@@ -5,17 +5,22 @@ import io.cucumber.java8.En
 import s2.bdd.S2CucumberStepsDefinition
 import s2.bdd.assertion.AssertionBdd
 import s2.bdd.assertion.exceptions
+import s2.bdd.data.TestContext
 import s2.bdd.data.TestContextKey
+import s2.bdd.data.TestEntities
 import s2.bdd.data.parser.safeExtract
+
+internal fun TestContext.entityListOrFail(objectName: String): TestEntities<*, *> {
+    return entityLists[objectName]
+        ?: error("No entity list registered for \"$objectName\"")
+}
 
 class NotFoundExceptionAssertionSteps: En, S2CucumberStepsDefinition() {
     init {
         DataTableType(::notFoundParams)
 
         Then("The {string} should not be found") { objectName: String ->
-            val entityList = context.entityLists[objectName]
-                ?: error("No entity list registered for \"$objectName\"")
-            assert(entityList.lastUsedKey.toString())
+            assert(context.entityListOrFail(objectName).lastUsedKey.toString())
         }
 
     }

--- a/s2-test/s2-test-bdd/src/test/kotlin/s2/bdd/CucumberStepsDefinitionTest.kt
+++ b/s2-test/s2-test-bdd/src/test/kotlin/s2/bdd/CucumberStepsDefinitionTest.kt
@@ -1,0 +1,107 @@
+package s2.bdd
+
+import kotlinx.coroutines.reactor.ReactorContext
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import org.springframework.security.core.context.SecurityContext
+import reactor.core.publisher.Mono
+import s2.automate.core.error.AutomateException
+import s2.bdd.auth.AuthedUser
+import s2.bdd.data.TestContext
+import s2.dsl.automate.s2error
+
+class CucumberStepsDefinitionTest {
+
+    private class Steps(
+        public override val context: TestContext = TestContext(),
+    ) : CucumberStepsDefinition() {
+        fun random(value: String?) = value.orRandom()
+        fun nullValue(value: String) = value.parseNullValue()
+        fun nullableOrDefault(value: String?, default: String?) = value.parseNullableOrDefault(default)
+        fun <T> nullableOrDefault(value: String?, default: T?, parse: (String) -> T?) =
+            value.parseNullableOrDefault(default, parse)
+
+        fun runStep(block: suspend () -> Unit) = step(block)
+        fun runStep(propagate: (Exception) -> Boolean, block: suspend () -> Unit) = step(propagate, block)
+        fun authed() = authedContext()
+    }
+
+    @Test
+    fun `orRandom keeps the value and generates one when null`() {
+        val steps = Steps()
+        assertThat(steps.random("fixed")).isEqualTo("fixed")
+        assertThat(steps.random(null)).isNotBlank()
+        assertThat(steps.random(null)).isNotEqualTo(steps.random(null))
+    }
+
+    @Test
+    fun `parseNullValue turns the null literal into null`() {
+        val steps = Steps()
+        assertThat(steps.nullValue("null")).isNull()
+        assertThat(steps.nullValue("value")).isEqualTo("value")
+    }
+
+    @Test
+    fun `parseNullableOrDefault handles null literal and default`() {
+        val steps = Steps()
+        assertThat(steps.nullableOrDefault(null, "default")).isEqualTo("default")
+        assertThat(steps.nullableOrDefault("null", "default")).isNull()
+        assertThat(steps.nullableOrDefault("7", 0) { it.toInt() }).isEqualTo(7)
+    }
+
+    @Test
+    fun `step runs the block in an authenticated coroutine`() {
+        val steps = Steps()
+        var executed = false
+        steps.runStep { executed = true }
+        assertThat(executed).isTrue()
+    }
+
+    @Test
+    fun `step records an AutomateException without propagating it`() {
+        val steps = Steps()
+        steps.runStep {
+            throw AutomateException(listOf(s2error("CODE", "boom")))
+        }
+        assertThat(steps.context.errors.lastOfType(AutomateException::class)).isNotNull()
+    }
+
+    @Test
+    fun `step records and rethrows unexpected exceptions`() {
+        val steps = Steps()
+        assertThatThrownBy {
+            steps.runStep { throw IllegalStateException("unexpected") }
+        }.isInstanceOf(IllegalStateException::class.java)
+        assertThat(steps.context.errors.lastOfType(IllegalStateException::class)).isNotNull()
+    }
+
+    @Test
+    fun `step honors a custom propagation predicate`() {
+        val steps = Steps()
+        steps.runStep({ false }) { throw IllegalStateException("swallowed") }
+        assertThat(steps.context.errors.lastOfType(IllegalStateException::class)).isNotNull()
+    }
+
+    @Test
+    fun `authedContext is empty without an authenticated user`() {
+        val steps = Steps()
+        val reactorContext: ReactorContext = steps.authed()
+        @Suppress("UNCHECKED_CAST")
+        val securityContext =
+            reactorContext.context.get<Mono<SecurityContext>>(SecurityContext::class.java)
+        assertThat(securityContext.blockOptional()).isEmpty()
+    }
+
+    @Test
+    fun `authedContext builds a jwt authentication for the authed user`() {
+        val steps = Steps()
+        steps.context.authedUser = AuthedUser(id = "user-1", memberOf = "org-1", roles = arrayOf("admin"))
+        val reactorContext = steps.authed()
+        @Suppress("UNCHECKED_CAST")
+        val securityContext =
+            reactorContext.context.get<Mono<SecurityContext>>(SecurityContext::class.java)
+        val authentication = securityContext.block()!!.authentication!!
+        assertThat(authentication.authorities.map { it.authority }).containsExactly("ROLE_admin")
+    }
+}

--- a/s2-test/s2-test-bdd/src/test/kotlin/s2/bdd/data/StubFilePartTest.kt
+++ b/s2-test/s2-test-bdd/src/test/kotlin/s2/bdd/data/StubFilePartTest.kt
@@ -1,0 +1,33 @@
+package s2.bdd.data
+
+import f2.dsl.cqrs.Event
+import java.nio.file.Path
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import s2.bdd.TestApplicationEventListener
+
+class StubFilePartTest {
+
+    @Test
+    fun `StubFilePart exposes its name as filename with empty content`() {
+        val part = StubFilePart("report.pdf")
+        assertThat(part.name()).isEqualTo("report.pdf")
+        assertThat(part.filename()).isEqualTo("report.pdf")
+        assertThat(part.headers().isEmpty).isTrue()
+        val buffers = part.content().collectList().block()!!
+        assertThat(buffers).hasSize(1)
+        assertThat(buffers.single().readableByteCount()).isZero()
+        assertThat(part.transferTo(Path.of("ignored")).blockOptional()).isEmpty()
+    }
+
+    private data class SomeEvent(val id: String) : Event
+
+    @Test
+    fun `TestApplicationEventListener stores application events in the context`() {
+        val context = TestContext()
+        val listener = TestApplicationEventListener(context)
+        val event = SomeEvent("evt-1")
+        listener.onApplicationEvent(event)
+        assertThat(context.events).containsExactly(event)
+    }
+}

--- a/s2-test/s2-test-bdd/src/test/kotlin/s2/bdd/repository/AssertionApiEntityTest.kt
+++ b/s2-test/s2-test-bdd/src/test/kotlin/s2/bdd/repository/AssertionApiEntityTest.kt
@@ -1,0 +1,59 @@
+package s2.bdd.repository
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class AssertionApiEntityTest {
+
+    data class Entity(val id: String, val name: String)
+
+    private class EntityAsserter(val entity: Entity) {
+        fun hasName(name: String) = apply { assertThat(entity.name).isEqualTo(name) }
+    }
+
+    private class ApiAssertion(
+        private val store: Map<String, Entity>,
+    ) : AssertionApiEntity<Entity, String, EntityAsserter>() {
+        override suspend fun assertThat(entity: Entity) = EntityAsserter(entity)
+        override suspend fun findById(id: String): Entity? = store[id]
+    }
+
+    private val assertion = ApiAssertion(mapOf("1" to Entity("1", "one")))
+
+    @Test
+    suspend fun `exists passes when the entity is found`() {
+        assertion.exists("1")
+    }
+
+    @Test
+    suspend fun `exists fails when the entity is missing`() {
+        var failed = false
+        try {
+            assertion.exists("missing")
+        } catch (expected: AssertionError) {
+            failed = true
+        }
+        assertThat(failed).isTrue()
+    }
+
+    @Test
+    suspend fun `notExists passes when the entity is missing`() {
+        assertion.notExists("missing")
+    }
+
+    @Test
+    suspend fun `notExists fails when the entity is found`() {
+        var failed = false
+        try {
+            assertion.notExists("1")
+        } catch (expected: AssertionError) {
+            failed = true
+        }
+        assertThat(failed).isTrue()
+    }
+
+    @Test
+    suspend fun `assertThatId returns the entity asserter`() {
+        assertion.assertThatId("1").hasName("one")
+    }
+}

--- a/s2-test/s2-test-bdd/src/test/kotlin/s2/bdd/repository/AssertionCrudEntityTest.kt
+++ b/s2-test/s2-test-bdd/src/test/kotlin/s2/bdd/repository/AssertionCrudEntityTest.kt
@@ -1,0 +1,121 @@
+package s2.bdd.repository
+
+import java.util.Optional
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.reactivestreams.Publisher
+import org.springframework.data.repository.CrudRepository
+import org.springframework.data.repository.reactive.ReactiveCrudRepository
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
+
+class AssertionCrudEntityTest {
+
+    data class Entity(val id: String, val name: String)
+
+    private class EntityAsserter(val entity: Entity) {
+        fun hasName(name: String) = apply { assertThat(entity.name).isEqualTo(name) }
+    }
+
+    // ---- reactive ----
+
+    private class InMemoryReactiveRepository(
+        private val store: Map<String, Entity>,
+    ) : ReactiveCrudRepository<Entity, String> {
+        override fun findById(id: String): Mono<Entity> = Mono.justOrEmpty(store[id])
+        override fun findById(id: Publisher<String>): Mono<Entity> = Mono.from(id).flatMap { findById(it) }
+        override fun existsById(id: String): Mono<Boolean> = Mono.just(store.containsKey(id))
+        override fun existsById(id: Publisher<String>): Mono<Boolean> = Mono.from(id).flatMap { existsById(it) }
+        override fun <S : Entity> save(entity: S): Mono<S> = Mono.just(entity)
+        override fun <S : Entity> saveAll(entities: Iterable<S>): Flux<S> = Flux.fromIterable(entities)
+        override fun <S : Entity> saveAll(entityStream: Publisher<S>): Flux<S> = Flux.from(entityStream)
+        override fun findAll(): Flux<Entity> = Flux.fromIterable(store.values)
+        override fun findAllById(ids: Iterable<String>): Flux<Entity> =
+            Flux.fromIterable(ids.mapNotNull { store[it] })
+
+        override fun findAllById(idStream: Publisher<String>): Flux<Entity> =
+            Flux.from(idStream).mapNotNull { store[it] }
+
+        override fun count(): Mono<Long> = Mono.just(store.size.toLong())
+        override fun deleteById(id: String): Mono<Void> = Mono.empty()
+        override fun deleteById(id: Publisher<String>): Mono<Void> = Mono.empty()
+        override fun delete(entity: Entity): Mono<Void> = Mono.empty()
+        override fun deleteAllById(ids: Iterable<String>): Mono<Void> = Mono.empty()
+        override fun deleteAll(entities: Iterable<Entity>): Mono<Void> = Mono.empty()
+        override fun deleteAll(entityStream: Publisher<out Entity>): Mono<Void> = Mono.empty()
+        override fun deleteAll(): Mono<Void> = Mono.empty()
+    }
+
+    private class ReactiveAssertion(
+        override val repository: ReactiveCrudRepository<Entity, String>,
+    ) : AssertionCrudEntity<Entity, String, EntityAsserter>() {
+        override suspend fun assertThat(entity: Entity) = EntityAsserter(entity)
+    }
+
+    // ---- blocking ----
+
+    private class InMemoryBlockingRepository(
+        private val store: Map<String, Entity>,
+    ) : CrudRepository<Entity, String> {
+        override fun findById(id: String): Optional<Entity> = Optional.ofNullable(store[id])
+        override fun existsById(id: String): Boolean = store.containsKey(id)
+        override fun <S : Entity> save(entity: S): S = entity
+        override fun <S : Entity> saveAll(entities: Iterable<S>): Iterable<S> = entities
+        override fun findAll(): Iterable<Entity> = store.values
+        override fun findAllById(ids: Iterable<String>): Iterable<Entity> = ids.mapNotNull { store[it] }
+        override fun count(): Long = store.size.toLong()
+        override fun deleteById(id: String) = Unit
+        override fun delete(entity: Entity) = Unit
+        override fun deleteAllById(ids: Iterable<String>) = Unit
+        override fun deleteAll(entities: Iterable<Entity>) = Unit
+        override fun deleteAll() = Unit
+    }
+
+    private class BlockingAssertion(
+        override val repository: CrudRepository<Entity, String>,
+    ) : AssertionBlockingCrudEntity<Entity, String, EntityAsserter>() {
+        override suspend fun assertThat(entity: Entity) = EntityAsserter(entity)
+    }
+
+    private val store = mapOf("1" to Entity("1", "one"))
+
+    @Test
+    suspend fun `reactive assertion checks existence and asserts by id`() {
+        val assertion = ReactiveAssertion(InMemoryReactiveRepository(store))
+        assertion.exists("1")
+        assertion.notExists("missing")
+        assertion.assertThatId("1").hasName("one")
+    }
+
+    @Test
+    suspend fun `reactive assertion fails when existence does not match`() {
+        val assertion = ReactiveAssertion(InMemoryReactiveRepository(store))
+        var failed = false
+        try {
+            assertion.exists("missing")
+        } catch (expected: AssertionError) {
+            failed = true
+        }
+        assertThat(failed).isTrue()
+    }
+
+    @Test
+    suspend fun `blocking assertion checks existence and asserts by id`() {
+        val assertion = BlockingAssertion(InMemoryBlockingRepository(store))
+        assertion.exists("1")
+        assertion.notExists("missing")
+        assertion.assertThatId("1").hasName("one")
+    }
+
+    @Test
+    suspend fun `blocking assertion fails when existence does not match`() {
+        val assertion = BlockingAssertion(InMemoryBlockingRepository(store))
+        var failed = false
+        try {
+            assertion.notExists("1")
+        } catch (expected: AssertionError) {
+            failed = true
+        }
+        assertThat(failed).isTrue()
+    }
+}

--- a/s2-test/s2-test-bdd/src/test/kotlin/s2/bdd/step/exceptions/EntityListOrFailTest.kt
+++ b/s2-test/s2-test-bdd/src/test/kotlin/s2/bdd/step/exceptions/EntityListOrFailTest.kt
@@ -1,0 +1,27 @@
+package s2.bdd.step.exceptions
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import s2.bdd.data.TestContext
+
+class EntityListOrFailTest {
+
+    @Test
+    fun `entityListOrFail returns the registered entity list`() {
+        val context = TestContext()
+        val entities = context.testEntities<String, String>("order")
+        entities["key-1"] = "entity"
+        val found = context.entityListOrFail("order")
+        assertThat(found).isSameAs(entities)
+        assertThat(found.lastUsedKey).isEqualTo("key-1")
+    }
+
+    @Test
+    fun `entityListOrFail fails with a clear message for unknown lists`() {
+        val context = TestContext()
+        assertThatThrownBy { context.entityListOrFail("unknown") }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("unknown")
+    }
+}

--- a/sample/orderbook-sourcing/orderbook-sourcing-app-r2dbc/build.gradle.kts
+++ b/sample/orderbook-sourcing/orderbook-sourcing-app-r2dbc/build.gradle.kts
@@ -9,11 +9,11 @@ dependencies {
 	api(project(":sample:orderbook-sourcing:orderbook-sourcing-domain"))
 	api(project(":sample:orderbook-sourcing:orderbook-sourcing-core"))
 	api(project(":s2-spring:sourcing:s2-spring-boot-starter-sourcing-data-r2dbc"))
+	runtimeOnly(libs.postgresql)
+	runtimeOnly(libs.r2dbc.postgresql)
 
 	testImplementation(libs.bundles.testcontainers)
 	testImplementation(libs.bundles.testcontainers.postgres)
-	runtimeOnly(libs.postgresql)
-	runtimeOnly(libs.r2dbc.postgresql)
 	testImplementation(libs.spring.boot.starter.test)
 	testImplementation(libs.bundles.test.junit)
 }

--- a/sample/orderbook-sourcing/orderbook-sourcing-core/src/main/kotlin/s2/sample/orderbook/sourcing/core/redis/RedisSnapView.kt
+++ b/sample/orderbook-sourcing/orderbook-sourcing-core/src/main/kotlin/s2/sample/orderbook/sourcing/core/redis/RedisSnapView.kt
@@ -168,6 +168,8 @@ class RedisSnapView(
 			conn.reactive().ftSearch(MODEL::class.simpleName!!, "*").map { it.count }.awaitSingle()
 		}
 
+	// S6309: the whole search must run inside withConnection, the flow is materialized before returning.
+	@Suppress("kotlin:S6309")
 	suspend inline fun <reified MODEL> all(): Flow<MODEL> =
 		searchConnection.withConnection { conn ->
 			val connection = conn.reactive()


### PR DESCRIPTION
## SonarQube cleanup — 37/84 issues fixed, coverage 42.9% → ~75%

### Bug fixes (real behavior bugs)
- **`SpringDataAutomateCoroutinePersisterFlow`: `repository.saveAll(...)` Flow was never collected — entities were silently never saved.** Same latent Flux bug fixed in `SpringDataAutomateReactivePersisterFlow` (`.asFlow().collect()`)
- Unsafe map `!!` → safe access in `NotFoundExceptionAssertionSteps`

### Fixes
- `RetryTaskChannel` refactored to closure-queue (unchecked cast eliminated)
- `WithS2Id`, `WithS2State`, `View` → `fun interface` (JVM+JS verified)
- No-op listener methods documented, unused code removed, deprecated jakarta `@Temporal` removed, dependency grouping, stale TODO removed
- S100/S6309/S6514 suppressed with justification comments where fixing would break the published API (interface-mandated suspend overrides, ERROR_* naming)

### Tests (19 new files, 2002 lines, all `@Test suspend fun`)
Module line coverage: s2-automate-core 87.5%, s2-event-sourcing-dsl 96.8%, s2-test-bdd 67.4%, s2-automate-dsl 63%. Estimated project ~75%.

Known ceilings: dsl builders are `inline reified` (JaCoCo cannot attribute inlined bytecode); remaining bdd gap needs a cucumber runtime; spring starters need containerized integration tests.

### Skipped (needs deliberate decision)
- SHA-pinning first-party komune-io reusable workflows (intentionally tracked `@main`)
- Gradle lockfile / verification-metadata (build-infra policy)
- Removing deprecated `GenericParser`/`RedisSnapView` (public API removal)

Verification: full `assemble` (JVM+JS), detekt, and tests for core/dsl/event-sourcing/bdd/storing/documenter modules green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Functional-interface support added for model identifiers, states, and sourcing views, enabling simpler lambda-based usage.

* **Bug Fixes**
  * Persistence flows now fully complete save operations before continuing.
  * Retry persistence actions execute more reliably without unnecessary type conversions.
  * Improved handling when requested test data or entities are unavailable.
  * MongoDB event loading and timestamp handling remain compatible with supported persistence flows.

* **Tests**
  * Expanded coverage for automation, sourcing, snapshots, guards, errors, builders, and BDD assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->