### PR TITLE
refactor!: remove suspend from Flow-returning S2 interfaces (S6309)

### DIFF
--- a/s2-automate/s2-automate-core/src/commonMain/kotlin/s2/automate/core/engine/S2AutomateEngine.kt
+++ b/s2-automate/s2-automate-core/src/commonMain/kotlin/s2/automate/core/engine/S2AutomateEngine.kt
@@ -12,12 +12,12 @@ import s2.dsl.automate.model.WithS2State
 interface S2AutomateEngine<STATE, ENTITY, ID, EVENT> where
 ENTITY : WithS2State<STATE>,
 STATE : S2State {
-    suspend fun <COMMAND: S2InitCommand, ENTITY_OUT: ENTITY, EVENT_OUT : EVENT> create(
+    fun <COMMAND: S2InitCommand, ENTITY_OUT: ENTITY, EVENT_OUT : EVENT> create(
         commands: EnvelopedFlow<COMMAND>,
         decide: suspend (cmd: Envelope<COMMAND>) -> Pair<ENTITY_OUT, Envelope<EVENT_OUT>>
     ): EnvelopedFlow<EVENT_OUT>
 
-    suspend fun <COMMAND: S2Command<ID>, ENTITY_OUT: ENTITY, EVENT_OUT : EVENT> doTransition(
+    fun <COMMAND: S2Command<ID>, ENTITY_OUT: ENTITY, EVENT_OUT : EVENT> doTransition(
         commands: EnvelopedFlow<COMMAND>,
         exec: suspend (Envelope<out COMMAND>, ENTITY) -> Pair<ENTITY_OUT, Envelope<EVENT_OUT>>
     ): EnvelopedFlow<EVENT_OUT>

--- a/s2-automate/s2-automate-core/src/commonMain/kotlin/s2/automate/core/engine/S2AutomateEngineBase.kt
+++ b/s2-automate/s2-automate-core/src/commonMain/kotlin/s2/automate/core/engine/S2AutomateEngineBase.kt
@@ -91,7 +91,7 @@ ENTITY : WithS2Id<ID> {
         )
     }
 
-    protected suspend fun <COMMAND : S2Command<ID>> loadTransitionContext(
+    protected fun <COMMAND : S2Command<ID>> loadTransitionContext(
         commands: EnvelopedFlow<COMMAND>
     ): Flow<Pair<ENTITY, TransitionContext<STATE, ID, ENTITY, S2Automate, out COMMAND>>> {
         return commands.chunk(automateContext.batch.size).map { commandsChunk ->

--- a/s2-automate/s2-automate-core/src/commonMain/kotlin/s2/automate/core/engine/S2AutomateEngineImpl.kt
+++ b/s2-automate/s2-automate-core/src/commonMain/kotlin/s2/automate/core/engine/S2AutomateEngineImpl.kt
@@ -33,7 +33,7 @@ STATE : S2State,
 ENTITY : WithS2State<STATE>,
 ENTITY : WithS2Id<ID> {
 
-    override suspend fun <COMMAND : S2InitCommand, ENTITY_OUT : ENTITY, EVENT_OUT : EVENT> create(
+    override fun <COMMAND : S2InitCommand, ENTITY_OUT : ENTITY, EVENT_OUT : EVENT> create(
         commands: EnvelopedFlow<COMMAND>,
         decide: suspend (cmd: Envelope<COMMAND>) -> Pair<ENTITY_OUT, Envelope<EVENT_OUT>>
     ): EnvelopedFlow<EVENT_OUT> {
@@ -47,7 +47,7 @@ ENTITY : WithS2Id<ID> {
         }
     }
 
-    override suspend fun <COMMAND : S2Command<ID>, ENTITY_OUT : ENTITY, EVENT_OUT : EVENT> doTransition(
+    override fun <COMMAND : S2Command<ID>, ENTITY_OUT : ENTITY, EVENT_OUT : EVENT> doTransition(
         commands: EnvelopedFlow<COMMAND>,
         exec: suspend (Envelope<out COMMAND>, ENTITY) -> Pair<ENTITY_OUT, Envelope<EVENT_OUT>>
     ): EnvelopedFlow<EVENT_OUT> {
@@ -74,7 +74,7 @@ ENTITY : WithS2Id<ID> {
         }.flattenConcurrently(automateContext.batch.concurrency).mapToEnvelopeWithRandomId(type = "Evt")
     }
 
-    private suspend fun persistInit(
+    private fun persistInit(
         contexts: Flow<InitTransitionAppliedContext<STATE, ID, ENTITY, EVENT, S2Automate>>
     ): EnvelopedFlow<EVENT> {
         return contexts.map {
@@ -85,7 +85,7 @@ ENTITY : WithS2Id<ID> {
         }
     }
 
-    private suspend fun persist(
+    private fun persist(
         contexts: Flow<TransitionAppliedContext<STATE, ID, ENTITY, EVENT, S2Automate>>
     ): Flow<EVENT> {
         return contexts.map {

--- a/s2-automate/s2-automate-core/src/commonMain/kotlin/s2/automate/core/engine/S2AutomateOutcomeEngine.kt
+++ b/s2-automate/s2-automate-core/src/commonMain/kotlin/s2/automate/core/engine/S2AutomateOutcomeEngine.kt
@@ -12,12 +12,12 @@ interface S2AutomateOutcomeEngine<STATE, ENTITY, ID, EVENT> where
 ENTITY : WithS2State<STATE>,
 STATE : S2State {
 
-    suspend fun <COMMAND : S2InitCommand, ENTITY_OUT : ENTITY, EVENT_OUT : EVENT> createWithOutcomes(
+    fun <COMMAND : S2InitCommand, ENTITY_OUT : ENTITY, EVENT_OUT : EVENT> createWithOutcomes(
         commands: EnvelopedFlow<COMMAND>,
         decide: suspend (cmd: Envelope<COMMAND>) -> Pair<ENTITY_OUT, Envelope<EVENT_OUT>>
     ): EnvelopedFlow<PersistOutcome<EVENT_OUT>>
 
-    suspend fun <COMMAND : S2Command<ID>, ENTITY_OUT : ENTITY, EVENT_OUT : EVENT> doTransitionWithOutcomes(
+    fun <COMMAND : S2Command<ID>, ENTITY_OUT : ENTITY, EVENT_OUT : EVENT> doTransitionWithOutcomes(
         commands: EnvelopedFlow<COMMAND>,
         exec: suspend (Envelope<out COMMAND>, ENTITY) -> Pair<ENTITY_OUT, Envelope<EVENT_OUT>>
     ): EnvelopedFlow<PersistOutcome<EVENT_OUT>>

--- a/s2-automate/s2-automate-core/src/commonMain/kotlin/s2/automate/core/engine/S2AutomateOutcomeEngineImpl.kt
+++ b/s2-automate/s2-automate-core/src/commonMain/kotlin/s2/automate/core/engine/S2AutomateOutcomeEngineImpl.kt
@@ -42,7 +42,7 @@ ENTITY : WithS2State<STATE>,
 ENTITY : WithS2Id<ID> {
 
     // B.1: chunk-based streaming instead of unbounded toList
-    override suspend fun <COMMAND : S2InitCommand, ENTITY_OUT : ENTITY, EVENT_OUT : EVENT> createWithOutcomes(
+    override fun <COMMAND : S2InitCommand, ENTITY_OUT : ENTITY, EVENT_OUT : EVENT> createWithOutcomes(
         commands: EnvelopedFlow<COMMAND>,
         decide: suspend (cmd: Envelope<COMMAND>) -> Pair<ENTITY_OUT, Envelope<EVENT_OUT>>
     ): EnvelopedFlow<PersistOutcome<EVENT_OUT>> {
@@ -54,7 +54,7 @@ ENTITY : WithS2Id<ID> {
     }
 
     // B.2: batched load per chunk; B.3: msgId-keyed correlation
-    override suspend fun <COMMAND : S2Command<ID>, ENTITY_OUT : ENTITY, EVENT_OUT : EVENT> doTransitionWithOutcomes(
+    override fun <COMMAND : S2Command<ID>, ENTITY_OUT : ENTITY, EVENT_OUT : EVENT> doTransitionWithOutcomes(
         commands: EnvelopedFlow<COMMAND>,
         exec: suspend (Envelope<out COMMAND>, ENTITY) -> Pair<ENTITY_OUT, Envelope<EVENT_OUT>>
     ): EnvelopedFlow<PersistOutcome<EVENT_OUT>> {
@@ -172,7 +172,7 @@ ENTITY : WithS2Id<ID> {
         }
     }
 
-    private suspend fun persistInitWithOutcomes(
+    private fun persistInitWithOutcomes(
         contexts: Flow<InitTransitionAppliedContext<STATE, ID, ENTITY, EVENT, S2Automate>>
     ): EnvelopedFlow<PersistOutcome<EVENT>> {
         return contexts.map {
@@ -183,7 +183,7 @@ ENTITY : WithS2Id<ID> {
         }
     }
 
-    private suspend fun persistWithOutcomes(
+    private fun persistWithOutcomes(
         contexts: Flow<TransitionAppliedContext<STATE, ID, ENTITY, EVENT, S2Automate>>
     ): Flow<PersistOutcome<EVENT>> {
         return contexts.map {

--- a/s2-automate/s2-automate-core/src/commonMain/kotlin/s2/automate/core/persist/AutomatePersister.kt
+++ b/s2-automate/s2-automate-core/src/commonMain/kotlin/s2/automate/core/persist/AutomatePersister.kt
@@ -20,15 +20,15 @@ STATE : S2State,
 ENTITY : WithS2State<STATE>,
 ENTITY : WithS2Id<ID> {
 
-	suspend fun persistInit(
+	fun persistInit(
 		transitionContexts: Flow<InitTransitionAppliedContext<STATE, ID, ENTITY, EVENT, AUTOMATE>>
 	): Flow<EVENT>
 
-	suspend fun persist(
+	fun persist(
 		transitionContexts: Flow<TransitionAppliedContext<STATE, ID, ENTITY, EVENT, AUTOMATE>>
 	): Flow<EVENT>
 
-	suspend fun load(automateContexts: AutomateContext<AUTOMATE>, ids: Flow<ID & Any>): Flow<ENTITY?>
+	fun load(automateContexts: AutomateContext<AUTOMATE>, ids: Flow<ID & Any>): Flow<ENTITY?>
 
 	suspend fun load(automateContexts: AutomateContext<AUTOMATE>, id: ID & Any): ENTITY?
 
@@ -49,7 +49,7 @@ ENTITY : WithS2Id<ID> {
 	 * directly — overriding it is the supported way to surface rich failures
 	 * without aborting sibling commands in the same batch.
 	 */
-	suspend fun loadWithOutcomes(
+	fun loadWithOutcomes(
 		automateContexts: AutomateContext<AUTOMATE>,
 		ids: Flow<ID & Any>,
 	): Flow<LoadOutcome<ID & Any, ENTITY>> = flow {
@@ -85,7 +85,7 @@ ENTITY : WithS2Id<ID> {
 		}
 	}
 
-	suspend fun persistInitWithOutcomes(
+	fun persistInitWithOutcomes(
 		transitionContexts: Flow<InitTransitionAppliedContext<STATE, ID, ENTITY, EVENT, AUTOMATE>>
 	): Flow<PersistOutcome<EVENT>> = flow {
 		transitionContexts.collect { ctx ->
@@ -95,7 +95,7 @@ ENTITY : WithS2Id<ID> {
 		}
 	}
 
-	suspend fun persistWithOutcomes(
+	fun persistWithOutcomes(
 		transitionContexts: Flow<TransitionAppliedContext<STATE, ID, ENTITY, EVENT, AUTOMATE>>
 	): Flow<PersistOutcome<EVENT>> = flow {
 		transitionContexts.collect { ctx ->

--- a/s2-automate/s2-automate-core/src/commonMain/kotlin/s2/automate/core/sourcing/S2AutomateSourcingDeciderFlow.kt
+++ b/s2-automate/s2-automate-core/src/commonMain/kotlin/s2/automate/core/sourcing/S2AutomateSourcingDeciderFlow.kt
@@ -10,12 +10,12 @@ import s2.sourcing.dsl.Decide
 
 interface S2AutomateSourcingDeciderFlow<ENTITY : WithS2State<STATE>, STATE : S2State, EVENT: Evt, ID> {
 
-	suspend fun <COMMAND: S2InitCommand, EVENT_OUT: EVENT> decide(
+	fun <COMMAND: S2InitCommand, EVENT_OUT: EVENT> decide(
 		commands: Flow<COMMAND>,
 		buildEvent: suspend (cmd: COMMAND) -> EVENT_OUT
 	): Flow<EVENT_OUT>
 
-	suspend fun <COMMAND: S2Command<ID>, EVENT_OUT: EVENT> decide(
+	fun <COMMAND: S2Command<ID>, EVENT_OUT: EVENT> decide(
 		commands: Flow<COMMAND>,
 		exec: suspend (COMMAND, ENTITY) -> EVENT_OUT
 	): Flow<EVENT_OUT>

--- a/s2-automate/s2-automate-core/src/commonMain/kotlin/s2/automate/core/sourcing/S2AutomateSourcingDeciderImpl.kt
+++ b/s2-automate/s2-automate-core/src/commonMain/kotlin/s2/automate/core/sourcing/S2AutomateSourcingDeciderImpl.kt
@@ -44,7 +44,7 @@ ENTITY : WithS2State<STATE> {
 			}
 		}
 
-	override suspend fun <COMMAND: S2InitCommand, EVENT_OUT : EVENT> decide(
+	override fun <COMMAND: S2InitCommand, EVENT_OUT : EVENT> decide(
 		commands: Flow<COMMAND>,
 		buildEvent: suspend (cmd: COMMAND) -> EVENT_OUT
 	): Flow<EVENT_OUT> {
@@ -64,10 +64,10 @@ ENTITY : WithS2State<STATE> {
 		}
 	}
 
-	suspend fun loadAll() = eventStore.loadAll()
-	suspend fun load(id: ID) = eventStore.load(id)
+	fun loadAll() = eventStore.loadAll()
+	fun load(id: ID) = eventStore.load(id)
 
-	override suspend fun <COMMAND: S2Command<ID>, EVENT_OUT : EVENT,> decide(
+	override fun <COMMAND: S2Command<ID>, EVENT_OUT : EVENT,> decide(
 		commands: Flow<COMMAND>,
 		exec: suspend (COMMAND, ENTITY) -> EVENT_OUT
 	): Flow<EVENT_OUT> {

--- a/s2-automate/s2-automate-core/src/commonMain/kotlin/s2/automate/core/storing/S2AutomateStoringEvolverFlow.kt
+++ b/s2-automate/s2-automate-core/src/commonMain/kotlin/s2/automate/core/storing/S2AutomateStoringEvolverFlow.kt
@@ -15,12 +15,12 @@ typealias S2EvolveFnc<COMMAND, ENTITY, EVENT_OUT> = suspend (COMMAND, ENTITY) ->
 
 interface S2AutomateStoringEvolverFlow<STATE : S2State, ID, ENTITY : WithS2State<STATE>, EVENT: Evt> {
 
-	suspend fun <COMMAND: S2InitCommand, EVENT_OUT: EVENT> evolve(
+	fun <COMMAND: S2InitCommand, EVENT_OUT: EVENT> evolve(
 		commands: Flow<COMMAND>,
 		build: S2EvolveInitFnc<COMMAND, ENTITY, EVENT_OUT>
 	): Flow<EVENT_OUT>
 
-	suspend fun <COMMAND: S2InitCommand, EVENT_OUT: EVENT> evolveEnvelope(
+	fun <COMMAND: S2InitCommand, EVENT_OUT: EVENT> evolveEnvelope(
 		commands: EnvelopedFlow<COMMAND>,
 		build: S2EvolveInitFnc<COMMAND, ENTITY, EVENT_OUT>
 	): EnvelopedFlow<EVENT_OUT>
@@ -29,12 +29,12 @@ interface S2AutomateStoringEvolverFlow<STATE : S2State, ID, ENTITY : WithS2State
 		build: S2EvolveInitFnc<COMMAND, ENTITY, EVENT_OUT>
 	): Decide<COMMAND, EVENT_OUT>
 
-	suspend fun <COMMAND: S2Command<ID>, EVENT_OUT: EVENT> evolve(
+	fun <COMMAND: S2Command<ID>, EVENT_OUT: EVENT> evolve(
 		commands: Flow<COMMAND>,
 		exec: S2EvolveFnc<COMMAND, ENTITY, EVENT_OUT>
 	): Flow<EVENT_OUT>
 
-	suspend fun <COMMAND: S2Command<ID>, EVENT_OUT: EVENT> evolveEnvelope(
+	fun <COMMAND: S2Command<ID>, EVENT_OUT: EVENT> evolveEnvelope(
 		commands: EnvelopedFlow<COMMAND>,
 		exec: S2EvolveFnc<COMMAND, ENTITY, EVENT_OUT>
 	): EnvelopedFlow<EVENT_OUT>
@@ -43,13 +43,13 @@ interface S2AutomateStoringEvolverFlow<STATE : S2State, ID, ENTITY : WithS2State
 		fnc: S2EvolveFnc<COMMAND, ENTITY, EVENT_OUT>
 	): Decide<COMMAND, EVENT_OUT>
 
-	suspend fun <COMMAND: S2InitCommand, EVENT_OUT: EVENT> evolveWithOutcomes(
+	fun <COMMAND: S2InitCommand, EVENT_OUT: EVENT> evolveWithOutcomes(
 		commands: Flow<COMMAND>,
 		idOf: (COMMAND) -> String,
 		build: S2EvolveInitFnc<COMMAND, ENTITY, EVENT_OUT>
 	): Flow<PersistOutcome<EVENT_OUT>>
 
-	suspend fun <COMMAND: S2Command<ID>, EVENT_OUT: EVENT> evolveWithOutcomes(
+	fun <COMMAND: S2Command<ID>, EVENT_OUT: EVENT> evolveWithOutcomes(
 		commands: Flow<COMMAND>,
 		idOf: (COMMAND) -> String,
 		exec: S2EvolveFnc<COMMAND, ENTITY, EVENT_OUT>

--- a/s2-automate/s2-automate-core/src/commonMain/kotlin/s2/automate/core/storing/S2AutomateStoringEvolverImpl.kt
+++ b/s2-automate/s2-automate-core/src/commonMain/kotlin/s2/automate/core/storing/S2AutomateStoringEvolverImpl.kt
@@ -73,7 +73,7 @@ open class S2AutomateStoringEvolverImpl<STATE, ENTITY, ID>(
         return event.data
     }
 
-    override suspend fun <COMMAND : S2InitCommand, EVENT_OUT : Evt> evolve(
+    override fun <COMMAND : S2InitCommand, EVENT_OUT : Evt> evolve(
         commands: Flow<COMMAND>,
         build: suspend (cmd: COMMAND) -> Pair<ENTITY, EVENT_OUT>
     ): Flow<EVENT_OUT> {
@@ -87,7 +87,7 @@ open class S2AutomateStoringEvolverImpl<STATE, ENTITY, ID>(
         }.map { it.data }
     }
 
-    override suspend fun <COMMAND : S2Command<ID>, EVENT_OUT : Evt> evolve(
+    override fun <COMMAND : S2Command<ID>, EVENT_OUT : Evt> evolve(
         commands: Flow<COMMAND>,
         exec: suspend (COMMAND, ENTITY) -> Pair<ENTITY, EVENT_OUT>
     ): Flow<EVENT_OUT> {
@@ -117,7 +117,7 @@ open class S2AutomateStoringEvolverImpl<STATE, ENTITY, ID>(
         }
     }
 
-    override suspend fun <COMMAND : S2InitCommand, EVENT_OUT : Evt> evolveEnvelope(
+    override fun <COMMAND : S2InitCommand, EVENT_OUT : Evt> evolveEnvelope(
         commands: EnvelopedFlow<COMMAND>,
         build: S2EvolveInitFnc<COMMAND, ENTITY, EVENT_OUT>
     ): EnvelopedFlow<EVENT_OUT> {
@@ -131,7 +131,7 @@ open class S2AutomateStoringEvolverImpl<STATE, ENTITY, ID>(
         }
     }
 
-    override suspend fun <COMMAND : S2Command<ID>, EVENT_OUT : Evt> evolveEnvelope(
+    override fun <COMMAND : S2Command<ID>, EVENT_OUT : Evt> evolveEnvelope(
         commands: EnvelopedFlow<COMMAND>,
         exec: S2EvolveFnc<COMMAND, ENTITY, EVENT_OUT>
     ): EnvelopedFlow<EVENT_OUT> {
@@ -145,7 +145,7 @@ open class S2AutomateStoringEvolverImpl<STATE, ENTITY, ID>(
         }
     }
 
-    override suspend fun <COMMAND : S2InitCommand, EVENT_OUT : Evt> evolveWithOutcomes(
+    override fun <COMMAND : S2InitCommand, EVENT_OUT : Evt> evolveWithOutcomes(
         commands: Flow<COMMAND>,
         idOf: (COMMAND) -> String,
         build: suspend (cmd: COMMAND) -> Pair<ENTITY, EVENT_OUT>
@@ -165,7 +165,7 @@ open class S2AutomateStoringEvolverImpl<STATE, ENTITY, ID>(
         }.map { it.data }
     }
 
-    override suspend fun <COMMAND : S2Command<ID>, EVENT_OUT : Evt> evolveWithOutcomes(
+    override fun <COMMAND : S2Command<ID>, EVENT_OUT : Evt> evolveWithOutcomes(
         commands: Flow<COMMAND>,
         idOf: (COMMAND) -> String,
         exec: suspend (COMMAND, ENTITY) -> Pair<ENTITY, EVENT_OUT>

--- a/s2-automate/s2-automate-core/src/commonTest/kotlin/s2/automate/core/engine/S2AutomateOutcomeEngineImplLoadOutcomesTest.kt
+++ b/s2-automate/s2-automate-core/src/commonTest/kotlin/s2/automate/core/engine/S2AutomateOutcomeEngineImplLoadOutcomesTest.kt
@@ -109,15 +109,15 @@ class S2AutomateOutcomeEngineImplLoadOutcomesTest {
         private val script: Map<String, LoadOutcome<String, TestEntity>>,
     ) : AutomatePersister<TestState, String, TestEntity, TestEvent, S2Automate> {
 
-        override suspend fun persistInit(
+        override fun persistInit(
             transitionContexts: Flow<InitTransitionAppliedContext<TestState, String, TestEntity, TestEvent, S2Automate>>
         ): Flow<TestEvent> = error("not used")
 
-        override suspend fun persist(
+        override fun persist(
             transitionContexts: Flow<TransitionAppliedContext<TestState, String, TestEntity, TestEvent, S2Automate>>
         ): Flow<TestEvent> = error("not used")
 
-        override suspend fun load(
+        override fun load(
             automateContexts: AutomateContext<S2Automate>,
             ids: Flow<String>,
         ): Flow<TestEntity?> = error("legacy load should not be called when loadWithOutcomes is overridden")
@@ -127,14 +127,14 @@ class S2AutomateOutcomeEngineImplLoadOutcomesTest {
             id: String,
         ): TestEntity? = error("legacy load should not be called")
 
-        override suspend fun loadWithOutcomes(
+        override fun loadWithOutcomes(
             automateContexts: AutomateContext<S2Automate>,
             ids: Flow<String>,
         ): Flow<LoadOutcome<String, TestEntity>> = ids.map { id ->
             script[id] ?: error("no script entry for id=$id")
         }
 
-        override suspend fun persistWithOutcomes(
+        override fun persistWithOutcomes(
             transitionContexts: Flow<TransitionAppliedContext<TestState, String, TestEntity, TestEvent, S2Automate>>
         ): Flow<PersistOutcome<TestEvent>> = transitionContexts.map { ctx ->
             PersistOutcome.Success(msgId = ctx.msgId, event = ctx.event)
@@ -149,15 +149,15 @@ class S2AutomateOutcomeEngineImplLoadOutcomesTest {
     private class LegacyThrowingPersister(private val cause: Throwable) :
         AutomatePersister<TestState, String, TestEntity, TestEvent, S2Automate> {
 
-        override suspend fun persistInit(
+        override fun persistInit(
             transitionContexts: Flow<InitTransitionAppliedContext<TestState, String, TestEntity, TestEvent, S2Automate>>
         ): Flow<TestEvent> = error("not used")
 
-        override suspend fun persist(
+        override fun persist(
             transitionContexts: Flow<TransitionAppliedContext<TestState, String, TestEntity, TestEvent, S2Automate>>
         ): Flow<TestEvent> = error("not used")
 
-        override suspend fun load(
+        override fun load(
             automateContexts: AutomateContext<S2Automate>,
             ids: Flow<String>,
         ): Flow<TestEntity?> = flow { throw cause }

--- a/s2-automate/s2-automate-core/src/commonTest/kotlin/s2/automate/core/engine/S2AutomateOutcomeEngineImplOuterExceptionTest.kt
+++ b/s2-automate/s2-automate-core/src/commonTest/kotlin/s2/automate/core/engine/S2AutomateOutcomeEngineImplOuterExceptionTest.kt
@@ -137,17 +137,17 @@ class S2AutomateOutcomeEngineImplOuterExceptionTest {
     private class EmptyPersister :
         AutomatePersister<TestState, String, TestEntity, TestEvent, S2Automate> {
 
-        override suspend fun persistInit(
+        override fun persistInit(
             transitionContexts: Flow<InitTransitionAppliedContext<
                 TestState, String, TestEntity, TestEvent, S2Automate>>
         ): Flow<TestEvent> = error("not used")
 
-        override suspend fun persist(
+        override fun persist(
             transitionContexts: Flow<TransitionAppliedContext<
                 TestState, String, TestEntity, TestEvent, S2Automate>>
         ): Flow<TestEvent> = error("not used")
 
-        override suspend fun load(
+        override fun load(
             automateContexts: AutomateContext<S2Automate>,
             ids: Flow<String>,
         ): Flow<TestEntity?> = ids.map { null }
@@ -162,17 +162,17 @@ class S2AutomateOutcomeEngineImplOuterExceptionTest {
     private class PassthroughPersister :
         AutomatePersister<TestState, String, TestEntity, TestEvent, S2Automate> {
 
-        override suspend fun persistInit(
+        override fun persistInit(
             transitionContexts: Flow<InitTransitionAppliedContext<
                 TestState, String, TestEntity, TestEvent, S2Automate>>
         ): Flow<TestEvent> = error("not used")
 
-        override suspend fun persist(
+        override fun persist(
             transitionContexts: Flow<TransitionAppliedContext<
                 TestState, String, TestEntity, TestEvent, S2Automate>>
         ): Flow<TestEvent> = error("not used")
 
-        override suspend fun load(
+        override fun load(
             automateContexts: AutomateContext<S2Automate>,
             ids: Flow<String>,
         ): Flow<TestEntity?> = ids.map { id -> TestEntity(id, TestState.Created) }
@@ -182,7 +182,7 @@ class S2AutomateOutcomeEngineImplOuterExceptionTest {
             id: String,
         ): TestEntity? = TestEntity(id, TestState.Created)
 
-        override suspend fun persistInitWithOutcomes(
+        override fun persistInitWithOutcomes(
             transitionContexts: Flow<InitTransitionAppliedContext<
                 TestState, String, TestEntity, TestEvent, S2Automate>>
         ): Flow<PersistOutcome<TestEvent>> = transitionContexts.map { ctx ->
@@ -192,7 +192,7 @@ class S2AutomateOutcomeEngineImplOuterExceptionTest {
             )
         }
 
-        override suspend fun persistWithOutcomes(
+        override fun persistWithOutcomes(
             transitionContexts: Flow<TransitionAppliedContext<
                 TestState, String, TestEntity, TestEvent, S2Automate>>
         ): Flow<PersistOutcome<TestEvent>> = transitionContexts.map { ctx ->

--- a/s2-automate/s2-automate-core/src/commonTest/kotlin/s2/automate/core/engine/S2AutomateOutcomeEngineImplReactivityTest.kt
+++ b/s2-automate/s2-automate-core/src/commonTest/kotlin/s2/automate/core/engine/S2AutomateOutcomeEngineImplReactivityTest.kt
@@ -104,17 +104,17 @@ class S2AutomateOutcomeEngineImplReactivityTest {
 
         var loadCallCount = 0
 
-        override suspend fun persistInit(
+        override fun persistInit(
             transitionContexts: Flow<InitTransitionAppliedContext<
                 TestState, String, TestEntity, Any, S2Automate>>
         ): Flow<Any> = error("not used")
 
-        override suspend fun persist(
+        override fun persist(
             transitionContexts: Flow<TransitionAppliedContext<
                 TestState, String, TestEntity, Any, S2Automate>>
         ): Flow<Any> = error("not used")
 
-        override suspend fun load(
+        override fun load(
             automateContexts: AutomateContext<S2Automate>,
             ids: Flow<String>,
         ): Flow<TestEntity?> {
@@ -127,14 +127,14 @@ class S2AutomateOutcomeEngineImplReactivityTest {
             id: String,
         ): TestEntity? = TestEntity(id, TestState.Created)
 
-        override suspend fun persistWithOutcomes(
+        override fun persistWithOutcomes(
             transitionContexts: Flow<TransitionAppliedContext<
                 TestState, String, TestEntity, Any, S2Automate>>
         ): Flow<PersistOutcome<Any>> = transitionContexts.map { ctx ->
             PersistOutcome.Success(msgId = ctx.msgId, event = ctx.event)
         }
 
-        override suspend fun persistInitWithOutcomes(
+        override fun persistInitWithOutcomes(
             transitionContexts: Flow<InitTransitionAppliedContext<
                 TestState, String, TestEntity, Any, S2Automate>>
         ): Flow<PersistOutcome<Any>> = transitionContexts.map { ctx ->

--- a/s2-automate/s2-automate-core/src/commonTest/kotlin/s2/automate/core/engine/S2AutomateOutcomeEngineImplWithOutcomesTest.kt
+++ b/s2-automate/s2-automate-core/src/commonTest/kotlin/s2/automate/core/engine/S2AutomateOutcomeEngineImplWithOutcomesTest.kt
@@ -5,6 +5,7 @@ import f2.dsl.cqrs.envelope.asEnvelopeWithType
 import f2.dsl.cqrs.enveloped.EnvelopedFlow
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest
@@ -97,15 +98,15 @@ class S2AutomateOutcomeEngineImplWithOutcomesTest {
         private val transitionPattern: List<OutcomeKind>,
     ) : AutomatePersister<TestState, String, TestEntity, TestEvent, S2Automate> {
 
-        override suspend fun persistInit(
+        override fun persistInit(
             transitionContexts: Flow<InitTransitionAppliedContext<TestState, String, TestEntity, TestEvent, S2Automate>>
         ): Flow<TestEvent> = error("persistInit must NOT be called on the WithOutcomes path")
 
-        override suspend fun persist(
+        override fun persist(
             transitionContexts: Flow<TransitionAppliedContext<TestState, String, TestEntity, TestEvent, S2Automate>>
         ): Flow<TestEvent> = error("persist must NOT be called on the WithOutcomes path")
 
-        override suspend fun load(
+        override fun load(
             automateContexts: AutomateContext<S2Automate>,
             ids: Flow<String>,
         ): Flow<TestEntity?> = ids.map { id -> TestEntity(id, TestState.Created) }
@@ -115,23 +116,23 @@ class S2AutomateOutcomeEngineImplWithOutcomesTest {
             id: String,
         ): TestEntity? = TestEntity(id, TestState.Created)
 
-        override suspend fun persistInitWithOutcomes(
+        override fun persistInitWithOutcomes(
             transitionContexts: Flow<InitTransitionAppliedContext<TestState, String, TestEntity, TestEvent, S2Automate>>
-        ): Flow<PersistOutcome<TestEvent>> {
+        ): Flow<PersistOutcome<TestEvent>> = flow {
             val ctxs = transitionContexts.toList()
-            return ctxs.mapIndexed { i, ctx ->
-                toOutcome(initPattern[i % initPattern.size], ctx.event)
-            }.asFlow()
+            ctxs.forEachIndexed { i, ctx ->
+                emit(toOutcome(initPattern[i % initPattern.size], ctx.event))
+            }
         }
 
-        override suspend fun persistWithOutcomes(
+        override fun persistWithOutcomes(
             transitionContexts: Flow<TransitionAppliedContext<TestState, String, TestEntity, TestEvent, S2Automate>>
-        ): Flow<PersistOutcome<TestEvent>> {
+        ): Flow<PersistOutcome<TestEvent>> = flow {
             val ctxs = transitionContexts.toList()
-            return ctxs.mapIndexed { i, ctx ->
+            ctxs.forEachIndexed { i, ctx ->
                 // Use the actual msgId from the context so B.3 correlation works correctly.
-                toOutcome(transitionPattern[i % transitionPattern.size], ctx.event, ctx.msgId)
-            }.asFlow()
+                emit(toOutcome(transitionPattern[i % transitionPattern.size], ctx.event, ctx.msgId))
+            }
         }
 
         private fun toOutcome(

--- a/s2-automate/s2-automate-core/src/commonTest/kotlin/s2/automate/core/persist/AutomatePersisterDefaultsTest.kt
+++ b/s2-automate/s2-automate-core/src/commonTest/kotlin/s2/automate/core/persist/AutomatePersisterDefaultsTest.kt
@@ -105,15 +105,15 @@ class AutomatePersisterDefaultsTest {
 		private val eventsToEmit: List<String>,
 	) : AutomatePersister<TestState, String, TestEntity, String, S2Automate> {
 
-		override suspend fun persistInit(
+		override fun persistInit(
 			transitionContexts: Flow<InitTransitionAppliedContext<TestState, String, TestEntity, String, S2Automate>>
 		): Flow<String> = flowOf(*eventsToEmit.toTypedArray())
 
-		override suspend fun persist(
+		override fun persist(
 			transitionContexts: Flow<TransitionAppliedContext<TestState, String, TestEntity, String, S2Automate>>
 		): Flow<String> = flowOf(*eventsToEmit.toTypedArray())
 
-		override suspend fun load(
+		override fun load(
 			automateContexts: AutomateContext<S2Automate>,
 			ids: Flow<String>,
 		): Flow<TestEntity?> = flowOf()

--- a/s2-automate/s2-automate-core/src/commonTest/kotlin/s2/automate/core/persist/AutomatePersisterLoadOutcomeDefaultsTest.kt
+++ b/s2-automate/s2-automate-core/src/commonTest/kotlin/s2/automate/core/persist/AutomatePersisterLoadOutcomeDefaultsTest.kt
@@ -77,15 +77,15 @@ class AutomatePersisterLoadOutcomeDefaultsTest {
     private class FullPersister :
         AutomatePersister<TestState, String, TestEntity, TestEvent, S2Automate> {
 
-        override suspend fun persistInit(
+        override fun persistInit(
             transitionContexts: Flow<InitTransitionAppliedContext<TestState, String, TestEntity, TestEvent, S2Automate>>
         ): Flow<TestEvent> = error("not used")
 
-        override suspend fun persist(
+        override fun persist(
             transitionContexts: Flow<TransitionAppliedContext<TestState, String, TestEntity, TestEvent, S2Automate>>
         ): Flow<TestEvent> = error("not used")
 
-        override suspend fun load(
+        override fun load(
             automateContexts: AutomateContext<S2Automate>,
             ids: Flow<String>,
         ): Flow<TestEntity?> = ids.map { id -> TestEntity(id, TestState.Created) }
@@ -103,15 +103,15 @@ class AutomatePersisterLoadOutcomeDefaultsTest {
     private class EmptyPersister :
         AutomatePersister<TestState, String, TestEntity, TestEvent, S2Automate> {
 
-        override suspend fun persistInit(
+        override fun persistInit(
             transitionContexts: Flow<InitTransitionAppliedContext<TestState, String, TestEntity, TestEvent, S2Automate>>
         ): Flow<TestEvent> = error("not used")
 
-        override suspend fun persist(
+        override fun persist(
             transitionContexts: Flow<TransitionAppliedContext<TestState, String, TestEntity, TestEvent, S2Automate>>
         ): Flow<TestEvent> = error("not used")
 
-        override suspend fun load(
+        override fun load(
             automateContexts: AutomateContext<S2Automate>,
             ids: Flow<String>,
         ): Flow<TestEntity?> = ids.map { null }
@@ -129,15 +129,15 @@ class AutomatePersisterLoadOutcomeDefaultsTest {
     private class PartialPersister(private val found: Set<String>) :
         AutomatePersister<TestState, String, TestEntity, TestEvent, S2Automate> {
 
-        override suspend fun persistInit(
+        override fun persistInit(
             transitionContexts: Flow<InitTransitionAppliedContext<TestState, String, TestEntity, TestEvent, S2Automate>>
         ): Flow<TestEvent> = error("not used")
 
-        override suspend fun persist(
+        override fun persist(
             transitionContexts: Flow<TransitionAppliedContext<TestState, String, TestEntity, TestEvent, S2Automate>>
         ): Flow<TestEvent> = error("not used")
 
-        override suspend fun load(
+        override fun load(
             automateContexts: AutomateContext<S2Automate>,
             ids: Flow<String>,
         ): Flow<TestEntity?> = ids.map { id ->
@@ -156,15 +156,15 @@ class AutomatePersisterLoadOutcomeDefaultsTest {
     private class ThrowingPersister(private val cause: Throwable) :
         AutomatePersister<TestState, String, TestEntity, TestEvent, S2Automate> {
 
-        override suspend fun persistInit(
+        override fun persistInit(
             transitionContexts: Flow<InitTransitionAppliedContext<TestState, String, TestEntity, TestEvent, S2Automate>>
         ): Flow<TestEvent> = error("not used")
 
-        override suspend fun persist(
+        override fun persist(
             transitionContexts: Flow<TransitionAppliedContext<TestState, String, TestEntity, TestEvent, S2Automate>>
         ): Flow<TestEvent> = error("not used")
 
-        override suspend fun load(
+        override fun load(
             automateContexts: AutomateContext<S2Automate>,
             ids: Flow<String>,
         ): Flow<TestEntity?> = kotlinx.coroutines.flow.flow { throw cause }

--- a/s2-automate/s2-automate-core/src/commonTest/kotlin/s2/automate/core/storing/S2AutomateStoringEvolverImplFailurePublishTest.kt
+++ b/s2-automate/s2-automate-core/src/commonTest/kotlin/s2/automate/core/storing/S2AutomateStoringEvolverImplFailurePublishTest.kt
@@ -67,12 +67,12 @@ class S2AutomateStoringEvolverImplFailurePublishTest {
     /** Legacy engine stub (create / doTransition only — no outcome methods). */
     private class LegacyEngine : S2AutomateEngine<TestState, TestEntity, String, Evt> {
 
-        override suspend fun <COMMAND : S2InitCommand, ENTITY_OUT : TestEntity, EVENT_OUT : Evt> create(
+        override fun <COMMAND : S2InitCommand, ENTITY_OUT : TestEntity, EVENT_OUT : Evt> create(
             commands: EnvelopedFlow<COMMAND>,
             decide: suspend (cmd: Envelope<COMMAND>) -> Pair<ENTITY_OUT, Envelope<EVENT_OUT>>
         ): EnvelopedFlow<EVENT_OUT> = commands.map { cmd -> decide(cmd).second }
 
-        override suspend fun <COMMAND : S2Command<String>, ENTITY_OUT : TestEntity, EVENT_OUT : Evt> doTransition(
+        override fun <COMMAND : S2Command<String>, ENTITY_OUT : TestEntity, EVENT_OUT : Evt> doTransition(
             commands: EnvelopedFlow<COMMAND>,
             exec: suspend (Envelope<out COMMAND>, TestEntity) -> Pair<ENTITY_OUT, Envelope<EVENT_OUT>>
         ): EnvelopedFlow<EVENT_OUT> = commands.map { cmd ->
@@ -93,7 +93,7 @@ class S2AutomateStoringEvolverImplFailurePublishTest {
         private fun nextOutcome(): PersistOutcome<Evt> = outcomes[idx++ % outcomes.size]
 
         @Suppress("UNCHECKED_CAST")
-        override suspend fun <COMMAND : S2InitCommand, ENTITY_OUT : TestEntity, EVENT_OUT : Evt>
+        override fun <COMMAND : S2InitCommand, ENTITY_OUT : TestEntity, EVENT_OUT : Evt>
         createWithOutcomes(
             commands: EnvelopedFlow<COMMAND>,
             decide: suspend (cmd: Envelope<COMMAND>) -> Pair<ENTITY_OUT, Envelope<EVENT_OUT>>
@@ -103,7 +103,7 @@ class S2AutomateStoringEvolverImplFailurePublishTest {
         }
 
         @Suppress("UNCHECKED_CAST")
-        override suspend fun <COMMAND : S2Command<String>, ENTITY_OUT : TestEntity, EVENT_OUT : Evt>
+        override fun <COMMAND : S2Command<String>, ENTITY_OUT : TestEntity, EVENT_OUT : Evt>
         doTransitionWithOutcomes(
             commands: EnvelopedFlow<COMMAND>,
             exec: suspend (Envelope<out COMMAND>, TestEntity) -> Pair<ENTITY_OUT, Envelope<EVENT_OUT>>

--- a/s2-automate/s2-automate-core/src/commonTest/kotlin/s2/automate/core/storing/S2AutomateStoringEvolverImplIdOfTest.kt
+++ b/s2-automate/s2-automate-core/src/commonTest/kotlin/s2/automate/core/storing/S2AutomateStoringEvolverImplIdOfTest.kt
@@ -42,7 +42,7 @@ class S2AutomateStoringEvolverImplIdOfTest {
 
     private class EnvelopeIdEchoOutcomeEngine : S2AutomateOutcomeEngine<TestState, TestEntity, String, Evt> {
 
-        override suspend fun <COMMAND : S2InitCommand, ENTITY_OUT : TestEntity, EVENT_OUT : Evt> createWithOutcomes(
+        override fun <COMMAND : S2InitCommand, ENTITY_OUT : TestEntity, EVENT_OUT : Evt> createWithOutcomes(
             commands: EnvelopedFlow<COMMAND>,
             decide: suspend (cmd: Envelope<COMMAND>) -> Pair<ENTITY_OUT, Envelope<EVENT_OUT>>
         ): EnvelopedFlow<PersistOutcome<EVENT_OUT>> = commands.map { cmd ->
@@ -51,7 +51,7 @@ class S2AutomateStoringEvolverImplIdOfTest {
             outcome.asEnvelopeWithType("PersistOutcome")
         }
 
-        override suspend fun <COMMAND : S2Command<String>, ENTITY_OUT : TestEntity, EVENT_OUT : Evt> doTransitionWithOutcomes(
+        override fun <COMMAND : S2Command<String>, ENTITY_OUT : TestEntity, EVENT_OUT : Evt> doTransitionWithOutcomes(
             commands: EnvelopedFlow<COMMAND>,
             exec: suspend (Envelope<out COMMAND>, TestEntity) -> Pair<ENTITY_OUT, Envelope<EVENT_OUT>>
         ): EnvelopedFlow<PersistOutcome<EVENT_OUT>> = commands.map { cmd ->
@@ -64,12 +64,12 @@ class S2AutomateStoringEvolverImplIdOfTest {
 
     /** Minimal legacy-engine stub so the impl can be instantiated. Not exercised by these tests. */
     private class UnusedLegacyEngine : S2AutomateEngine<TestState, TestEntity, String, Evt> {
-        override suspend fun <COMMAND : S2InitCommand, ENTITY_OUT : TestEntity, EVENT_OUT : Evt> create(
+        override fun <COMMAND : S2InitCommand, ENTITY_OUT : TestEntity, EVENT_OUT : Evt> create(
             commands: EnvelopedFlow<COMMAND>,
             decide: suspend (cmd: Envelope<COMMAND>) -> Pair<ENTITY_OUT, Envelope<EVENT_OUT>>
         ): EnvelopedFlow<EVENT_OUT> = error("not used in idOf propagation tests")
 
-        override suspend fun <COMMAND : S2Command<String>, ENTITY_OUT : TestEntity, EVENT_OUT : Evt> doTransition(
+        override fun <COMMAND : S2Command<String>, ENTITY_OUT : TestEntity, EVENT_OUT : Evt> doTransition(
             commands: EnvelopedFlow<COMMAND>,
             exec: suspend (Envelope<out COMMAND>, TestEntity) -> Pair<ENTITY_OUT, Envelope<EVENT_OUT>>
         ): EnvelopedFlow<EVENT_OUT> = error("not used in idOf propagation tests")

--- a/s2-automate/s2-automate-core/src/commonTest/kotlin/s2/automate/core/storing/S2AutomateStoringEvolverImplOutcomesTest.kt
+++ b/s2-automate/s2-automate-core/src/commonTest/kotlin/s2/automate/core/storing/S2AutomateStoringEvolverImplOutcomesTest.kt
@@ -75,12 +75,12 @@ class S2AutomateStoringEvolverImplOutcomesTest {
     /** Legacy engine stub (create / doTransition only — no outcome methods). */
     private inner class LegacyStubEngine : S2AutomateEngine<TestState, TestEntity, String, Evt> {
 
-        override suspend fun <COMMAND : S2InitCommand, ENTITY_OUT : TestEntity, EVENT_OUT : Evt> create(
+        override fun <COMMAND : S2InitCommand, ENTITY_OUT : TestEntity, EVENT_OUT : Evt> create(
             commands: EnvelopedFlow<COMMAND>,
             decide: suspend (cmd: Envelope<COMMAND>) -> Pair<ENTITY_OUT, Envelope<EVENT_OUT>>
         ): EnvelopedFlow<EVENT_OUT> = commands.map { cmd -> decide(cmd).second }
 
-        override suspend fun <COMMAND : S2Command<String>, ENTITY_OUT : TestEntity, EVENT_OUT : Evt> doTransition(
+        override fun <COMMAND : S2Command<String>, ENTITY_OUT : TestEntity, EVENT_OUT : Evt> doTransition(
             commands: EnvelopedFlow<COMMAND>,
             exec: suspend (Envelope<out COMMAND>, TestEntity) -> Pair<ENTITY_OUT, Envelope<EVENT_OUT>>
         ): EnvelopedFlow<EVENT_OUT> = commands.map { cmd ->
@@ -100,7 +100,7 @@ class S2AutomateStoringEvolverImplOutcomesTest {
         private var initIdx = 0
         private var transIdx = 0
 
-        override suspend fun <COMMAND : S2InitCommand, ENTITY_OUT : TestEntity, EVENT_OUT : Evt> createWithOutcomes(
+        override fun <COMMAND : S2InitCommand, ENTITY_OUT : TestEntity, EVENT_OUT : Evt> createWithOutcomes(
             commands: EnvelopedFlow<COMMAND>,
             decide: suspend (cmd: Envelope<COMMAND>) -> Pair<ENTITY_OUT, Envelope<EVENT_OUT>>
         ): EnvelopedFlow<PersistOutcome<EVENT_OUT>> = commands.map { cmd ->
@@ -110,7 +110,7 @@ class S2AutomateStoringEvolverImplOutcomesTest {
             toOutcome(kind, evtEnvelope.data).asEnvelopeWithType("Evt") as Envelope<PersistOutcome<EVENT_OUT>>
         }
 
-        override suspend fun <COMMAND : S2Command<String>, ENTITY_OUT : TestEntity, EVENT_OUT : Evt> doTransitionWithOutcomes(
+        override fun <COMMAND : S2Command<String>, ENTITY_OUT : TestEntity, EVENT_OUT : Evt> doTransitionWithOutcomes(
             commands: EnvelopedFlow<COMMAND>,
             exec: suspend (Envelope<out COMMAND>, TestEntity) -> Pair<ENTITY_OUT, Envelope<EVENT_OUT>>
         ): EnvelopedFlow<PersistOutcome<EVENT_OUT>> = commands.map { cmd ->

--- a/s2-automate/s2-automate-core/src/jvmTest/kotlin/s2/automate/core/engine/S2AutomateEngineBaseTest.kt
+++ b/s2-automate/s2-automate-core/src/jvmTest/kotlin/s2/automate/core/engine/S2AutomateEngineBaseTest.kt
@@ -94,16 +94,16 @@ class S2AutomateEngineBaseTest {
             id: String,
         ): TestEntity? = entities[id]
 
-        override suspend fun load(
+        override fun load(
             automateContexts: AutomateContext<S2Automate>,
             ids: Flow<String>,
         ): Flow<TestEntity?> = ids.map { entities[it] }
 
-        override suspend fun persistInit(
+        override fun persistInit(
             transitionContexts: Flow<InitTransitionAppliedContext<TestState, String, TestEntity, DoneEvt, S2Automate>>
         ): Flow<DoneEvt> = transitionContexts.map { it.event }
 
-        override suspend fun persist(
+        override fun persist(
             transitionContexts: Flow<TransitionAppliedContext<TestState, String, TestEntity, DoneEvt, S2Automate>>
         ): Flow<DoneEvt> = transitionContexts.map { it.event }
     }
@@ -222,7 +222,7 @@ class S2AutomateEngineBaseTest {
     @Test
     suspend fun `loadBatchWithOutcomes defaults absent outcomes to Rejected entity not found`() {
         val silentPersister = object : StubPersister(emptyMap()) {
-            override suspend fun loadWithOutcomes(
+            override fun loadWithOutcomes(
                 automateContexts: AutomateContext<S2Automate>,
                 ids: Flow<String>,
             ): Flow<LoadOutcome<String, TestEntity>> = emptyFlow()
@@ -261,7 +261,7 @@ class S2AutomateEngineBaseTest {
     suspend fun `loadTransitionContext fails when a loaded entity matches no command`() {
         // Persister answering with an entity whose id belongs to no command in the chunk.
         val misMatchedPersister = object : StubPersister(emptyMap()) {
-            override suspend fun load(
+            override fun load(
                 automateContexts: AutomateContext<S2Automate>,
                 ids: Flow<String>,
             ): Flow<TestEntity?> = ids.map { TestEntity("other", TestState.Created) }

--- a/s2-automate/s2-automate-core/src/jvmTest/kotlin/s2/automate/core/engine/S2AutomateEngineImplTest.kt
+++ b/s2-automate/s2-automate-core/src/jvmTest/kotlin/s2/automate/core/engine/S2AutomateEngineImplTest.kt
@@ -82,16 +82,16 @@ class S2AutomateEngineImplTest {
             id: String,
         ): TestEntity? = entities[id]
 
-        override suspend fun load(
+        override fun load(
             automateContexts: AutomateContext<S2Automate>,
             ids: Flow<String>,
         ): Flow<TestEntity?> = ids.map { entities[it] }
 
-        override suspend fun persistInit(
+        override fun persistInit(
             transitionContexts: Flow<InitTransitionAppliedContext<TestState, String, TestEntity, TestEvent, S2Automate>>
         ): Flow<TestEvent> = transitionContexts.map { it.event }
 
-        override suspend fun persist(
+        override fun persist(
             transitionContexts: Flow<TransitionAppliedContext<TestState, String, TestEntity, TestEvent, S2Automate>>
         ): Flow<TestEvent> = transitionContexts.map { it.event }
     }

--- a/s2-automate/s2-automate-core/src/jvmTest/kotlin/s2/automate/core/sourcing/S2AutomateSourcingDeciderImplTest.kt
+++ b/s2-automate/s2-automate-core/src/jvmTest/kotlin/s2/automate/core/sourcing/S2AutomateSourcingDeciderImplTest.kt
@@ -47,12 +47,12 @@ class S2AutomateSourcingDeciderImplTest {
     data class DoCmd(override val id: String) : S2Command<String>
 
     private class StubEngine : S2AutomateEngine<TestState, TestEntity, String, TestEvent> {
-        override suspend fun <COMMAND : S2InitCommand, ENTITY_OUT : TestEntity, EVENT_OUT : TestEvent> create(
+        override fun <COMMAND : S2InitCommand, ENTITY_OUT : TestEntity, EVENT_OUT : TestEvent> create(
             commands: EnvelopedFlow<COMMAND>,
             decide: suspend (cmd: Envelope<COMMAND>) -> Pair<ENTITY_OUT, Envelope<EVENT_OUT>>
         ): EnvelopedFlow<EVENT_OUT> = commands.map { command -> decide(command).second }
 
-        override suspend fun <COMMAND : S2Command<String>, ENTITY_OUT : TestEntity, EVENT_OUT : TestEvent>
+        override fun <COMMAND : S2Command<String>, ENTITY_OUT : TestEntity, EVENT_OUT : TestEvent>
         doTransition(
             commands: EnvelopedFlow<COMMAND>,
             exec: suspend (Envelope<out COMMAND>, TestEntity) -> Pair<ENTITY_OUT, Envelope<EVENT_OUT>>
@@ -86,12 +86,12 @@ class S2AutomateSourcingDeciderImplTest {
 
     private class StubEventRepository : EventRepository<TestEvent, String> {
         val stored = mutableListOf<TestEvent>(CreatedEvt("stored"))
-        override suspend fun load(id: String): Flow<TestEvent> =
+        override fun load(id: String): Flow<TestEvent> =
             flowOf(*stored.filter { it.s2Id() == id }.toTypedArray())
 
-        override suspend fun loadAll(): Flow<TestEvent> = flowOf(*stored.toTypedArray())
+        override fun loadAll(): Flow<TestEvent> = flowOf(*stored.toTypedArray())
         override suspend fun persist(event: TestEvent): TestEvent = event.also(stored::add)
-        override suspend fun persist(events: Flow<TestEvent>): Flow<TestEvent> = events
+        override fun persist(events: Flow<TestEvent>): Flow<TestEvent> = events
         override suspend fun createTable() { /* no-op for the stub */ }
     }
 

--- a/s2-automate/s2-automate-core/src/jvmTest/kotlin/s2/automate/core/storing/S2AutomateStoringEvolverImplTest.kt
+++ b/s2-automate/s2-automate-core/src/jvmTest/kotlin/s2/automate/core/storing/S2AutomateStoringEvolverImplTest.kt
@@ -54,12 +54,12 @@ class S2AutomateStoringEvolverImplTest {
     /** Passthrough engine: applies decide/exec and forwards the produced event envelope. */
     private inner class StubEngine : S2AutomateEngine<TestState, TestEntity, String, Evt> {
 
-        override suspend fun <COMMAND : S2InitCommand, ENTITY_OUT : TestEntity, EVENT_OUT : Evt> create(
+        override fun <COMMAND : S2InitCommand, ENTITY_OUT : TestEntity, EVENT_OUT : Evt> create(
             commands: EnvelopedFlow<COMMAND>,
             decide: suspend (cmd: Envelope<COMMAND>) -> Pair<ENTITY_OUT, Envelope<EVENT_OUT>>
         ): EnvelopedFlow<EVENT_OUT> = commands.map { cmd -> decide(cmd).second }
 
-        override suspend fun <COMMAND : S2Command<String>, ENTITY_OUT : TestEntity, EVENT_OUT : Evt> doTransition(
+        override fun <COMMAND : S2Command<String>, ENTITY_OUT : TestEntity, EVENT_OUT : Evt> doTransition(
             commands: EnvelopedFlow<COMMAND>,
             exec: suspend (Envelope<out COMMAND>, TestEntity) -> Pair<ENTITY_OUT, Envelope<EVENT_OUT>>
         ): EnvelopedFlow<EVENT_OUT> = commands.map { cmd ->
@@ -71,12 +71,12 @@ class S2AutomateStoringEvolverImplTest {
     /** The outcome engine must not be reached by the non-outcome paths under test. */
     private inner class UnreachableOutcomeEngine : S2AutomateOutcomeEngine<TestState, TestEntity, String, Evt> {
 
-        override suspend fun <COMMAND : S2InitCommand, ENTITY_OUT : TestEntity, EVENT_OUT : Evt> createWithOutcomes(
+        override fun <COMMAND : S2InitCommand, ENTITY_OUT : TestEntity, EVENT_OUT : Evt> createWithOutcomes(
             commands: EnvelopedFlow<COMMAND>,
             decide: suspend (cmd: Envelope<COMMAND>) -> Pair<ENTITY_OUT, Envelope<EVENT_OUT>>
         ): EnvelopedFlow<PersistOutcome<EVENT_OUT>> = error("outcome engine must not be used")
 
-        override suspend fun <COMMAND : S2Command<String>, ENTITY_OUT : TestEntity, EVENT_OUT : Evt> doTransitionWithOutcomes(
+        override fun <COMMAND : S2Command<String>, ENTITY_OUT : TestEntity, EVENT_OUT : Evt> doTransitionWithOutcomes(
             commands: EnvelopedFlow<COMMAND>,
             exec: suspend (Envelope<out COMMAND>, TestEntity) -> Pair<ENTITY_OUT, Envelope<EVENT_OUT>>
         ): EnvelopedFlow<PersistOutcome<EVENT_OUT>> = error("outcome engine must not be used")

--- a/s2-automate/s2-automate-documenter/build.gradle.kts
+++ b/s2-automate/s2-automate-documenter/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
 
 dependencies {
 	implementation(project(":s2-automate:s2-automate-dsl"))
+	implementation(libs.bundles.kserialization.json)
 
 	testImplementation(libs.bundles.test.junit)
 }

--- a/s2-event-sourcing/s2-event-sourcing-dsl/src/commonMain/kotlin/s2/sourcing/dsl/event/EventRepository.kt
+++ b/s2-event-sourcing/s2-event-sourcing-dsl/src/commonMain/kotlin/s2/sourcing/dsl/event/EventRepository.kt
@@ -6,9 +6,9 @@ import s2.dsl.automate.model.WithS2Id
 
 interface EventRepository<EVENT, ID>
 		where EVENT : Evt, EVENT : WithS2Id<ID> {
-	suspend fun load(id: ID): Flow<EVENT>
-	suspend fun loadAll(): Flow<EVENT>
+	fun load(id: ID): Flow<EVENT>
+	fun loadAll(): Flow<EVENT>
 	suspend fun persist(event: EVENT): EVENT
-	suspend fun persist(events: Flow<EVENT>): Flow<EVENT>
+	fun persist(events: Flow<EVENT>): Flow<EVENT>
 	suspend fun createTable()
 }

--- a/s2-event-sourcing/s2-event-sourcing-dsl/src/jvmTest/kotlin/s2/sourcing/dsl/snap/SnapLoaderTest.kt
+++ b/s2-event-sourcing/s2-event-sourcing-dsl/src/jvmTest/kotlin/s2/sourcing/dsl/snap/SnapLoaderTest.kt
@@ -23,12 +23,12 @@ class SnapLoaderTest {
     private class StubEventRepository(
         private val events: List<TestEvent>,
     ) : EventRepository<TestEvent, String> {
-        override suspend fun load(id: String): Flow<TestEvent> =
+        override fun load(id: String): Flow<TestEvent> =
             flowOf(*events.filter { it.s2Id() == id }.toTypedArray())
 
-        override suspend fun loadAll(): Flow<TestEvent> = flowOf(*events.toTypedArray())
+        override fun loadAll(): Flow<TestEvent> = flowOf(*events.toTypedArray())
         override suspend fun persist(event: TestEvent): TestEvent = event
-        override suspend fun persist(events: Flow<TestEvent>): Flow<TestEvent> = events
+        override fun persist(events: Flow<TestEvent>): Flow<TestEvent> = events
         override suspend fun createTable() { /* no-op for the stub */ }
     }
 

--- a/s2-event-sourcing/s2-event-sourcing-dsl/src/jvmTest/kotlin/s2/sourcing/dsl/view/SourcingViewExecutorImplTest.kt
+++ b/s2-event-sourcing/s2-event-sourcing-dsl/src/jvmTest/kotlin/s2/sourcing/dsl/view/SourcingViewExecutorImplTest.kt
@@ -20,10 +20,10 @@ class SourcingViewExecutorImplTest {
     }
 
     private class StubEventRepository : EventRepository<TestEvent, String> {
-        override suspend fun load(id: String): Flow<TestEvent> = flowOf(TestEvent(id, 10))
-        override suspend fun loadAll(): Flow<TestEvent> = flowOf()
+        override fun load(id: String): Flow<TestEvent> = flowOf(TestEvent(id, 10))
+        override fun loadAll(): Flow<TestEvent> = flowOf()
         override suspend fun persist(event: TestEvent): TestEvent = event
-        override suspend fun persist(events: Flow<TestEvent>): Flow<TestEvent> = events
+        override fun persist(events: Flow<TestEvent>): Flow<TestEvent> = events
         override suspend fun createTable() { /* no-op for the stub */ }
     }
 

--- a/s2-event-sourcing/s2-event-sourcing-dsl/src/jvmTest/kotlin/s2/sourcing/dsl/view/ViewLoaderLoadTest.kt
+++ b/s2-event-sourcing/s2-event-sourcing-dsl/src/jvmTest/kotlin/s2/sourcing/dsl/view/ViewLoaderLoadTest.kt
@@ -19,12 +19,12 @@ class ViewLoaderLoadTest {
     private class StubEventRepository(
         private val events: List<TestEvent>,
     ) : EventRepository<TestEvent, String> {
-        override suspend fun load(id: String): Flow<TestEvent> =
+        override fun load(id: String): Flow<TestEvent> =
             flowOf(*events.filter { it.s2Id() == id }.toTypedArray())
 
-        override suspend fun loadAll(): Flow<TestEvent> = flowOf(*events.toTypedArray())
+        override fun loadAll(): Flow<TestEvent> = flowOf(*events.toTypedArray())
         override suspend fun persist(event: TestEvent): TestEvent = event
-        override suspend fun persist(events: Flow<TestEvent>): Flow<TestEvent> = events
+        override fun persist(events: Flow<TestEvent>): Flow<TestEvent> = events
         override suspend fun createTable() { /* no-op for the stub */ }
     }
 

--- a/s2-event-sourcing/s2-event-sourcing-dsl/src/jvmTest/kotlin/s2/sourcing/dsl/view/ViewLoaderTest.kt
+++ b/s2-event-sourcing/s2-event-sourcing-dsl/src/jvmTest/kotlin/s2/sourcing/dsl/view/ViewLoaderTest.kt
@@ -52,7 +52,7 @@ class ViewLoaderTest {
     }
 
     class TestEventRepository : EventRepository<TestEvent, String> {
-        override suspend fun load(id: String): Flow<TestEvent> {
+        override fun load(id: String): Flow<TestEvent> {
             return when (id) {
                 "1" -> flowOf(
                     TestEvent("1", 1),
@@ -66,7 +66,7 @@ class ViewLoaderTest {
             }
         }
 
-        override suspend fun loadAll(): Flow<TestEvent> = flowOf(
+        override fun loadAll(): Flow<TestEvent> = flowOf(
             TestEvent("1", 3), // Out of order intentionally
             TestEvent("2", 2),
             TestEvent("1", 1), // Out of order intentionally
@@ -74,7 +74,7 @@ class ViewLoaderTest {
         )
 
         override suspend fun persist(event: TestEvent): TestEvent = event
-        override suspend fun persist(events: Flow<TestEvent>): Flow<TestEvent> = events
+        override fun persist(events: Flow<TestEvent>): Flow<TestEvent> = events
         override suspend fun createTable() {}
     }
 
@@ -92,7 +92,7 @@ class ViewLoaderTest {
     }
 
     class TestEventNonComparableRepository : EventRepository<TestEventNonComparable, String> {
-        override suspend fun load(id: String): Flow<TestEventNonComparable> {
+        override fun load(id: String): Flow<TestEventNonComparable> {
             return when (id) {
                 "1" -> flowOf(
                     TestEventNonComparable("1")
@@ -106,13 +106,13 @@ class ViewLoaderTest {
 
         // Load events in a specific order: first Entity-2, then Entity-1
         // Since they don't implement Comparable, this order should be preserved
-        override suspend fun loadAll(): Flow<TestEventNonComparable> = flowOf(
+        override fun loadAll(): Flow<TestEventNonComparable> = flowOf(
             TestEventNonComparable("2"),
             TestEventNonComparable("1")
         )
 
         override suspend fun persist(event: TestEventNonComparable): TestEventNonComparable = event
-        override suspend fun persist(events: Flow<TestEventNonComparable>): Flow<TestEventNonComparable> = events
+        override fun persist(events: Flow<TestEventNonComparable>): Flow<TestEventNonComparable> = events
         override suspend fun createTable() {}
     }
 

--- a/s2-spring/sourcing/s2-spring-boot-starter-sourcing-data-mongodb/build.gradle.kts
+++ b/s2-spring/sourcing/s2-spring-boot-starter-sourcing-data-mongodb/build.gradle.kts
@@ -6,4 +6,5 @@ plugins {
 dependencies {
 	api(project(":s2-spring:sourcing:s2-spring-boot-starter-sourcing-data"))
 	api(libs.spring.boot.starter.data.mongodb.reactive)
+	implementation(libs.bundles.kserialization.json)
 }

--- a/s2-spring/sourcing/s2-spring-boot-starter-sourcing-data-mongodb/build.gradle.kts
+++ b/s2-spring/sourcing/s2-spring-boot-starter-sourcing-data-mongodb/build.gradle.kts
@@ -1,10 +1,19 @@
 plugins {
 	alias(catalogue.plugins.fixers.gradle.kotlin.jvm)
 	alias(catalogue.plugins.fixers.gradle.publish)
+	alias(catalogue.plugins.kotlin.serialization)
 }
 
 dependencies {
 	api(project(":s2-spring:sourcing:s2-spring-boot-starter-sourcing-data"))
 	api(libs.spring.boot.starter.data.mongodb.reactive)
 	implementation(libs.bundles.kserialization.json)
+
+	// Test dependencies
+	// kotlinx-coroutines-reactor bridges the CoroutineCrudRepository suspend methods
+	// (save/findAll/count) to their reactive equivalents at runtime.
+	testImplementation(libs.kotlinx.coroutines.reactor)
+	testImplementation(libs.bundles.testcontainers)
+	testImplementation(libs.spring.boot.starter.test)
+	testImplementation(libs.bundles.test.junit)
 }

--- a/s2-spring/sourcing/s2-spring-boot-starter-sourcing-data-mongodb/src/main/kotlin/s2/spring/sourcing/data/mongodb/MongoEventRepository.kt
+++ b/s2-spring/sourcing/s2-spring-boot-starter-sourcing-data-mongodb/src/main/kotlin/s2/spring/sourcing/data/mongodb/MongoEventRepository.kt
@@ -12,8 +12,6 @@ import s2.dsl.automate.model.WithS2Id
 import s2.sourcing.dsl.event.EventRepository
 import s2.spring.sourcing.data.event.EventSourcing
 
-// S6309: the suspend modifier is mandated by the EventRepository contract (published API).
-@Suppress("kotlin:S6309")
 class MongoEventRepository<EVENT, ID>(
 	private val json: Json,
 	private val eventRepository: SpringDataEventRepository<EVENT, ID>,
@@ -23,16 +21,16 @@ EVENT: Evt,
 EVENT: WithS2Id<ID>
 {
 
-	override suspend fun load(id: ID): Flow<EVENT> {
+	override fun load(id: ID): Flow<EVENT> {
 		return eventRepository.findAllByObjId(id).toEvents()
 	}
 
-	override suspend fun loadAll(): Flow<EVENT> {
+	override fun loadAll(): Flow<EVENT> {
 		return eventRepository.findAll().toEvents()
 	}
 
 	@OptIn(InternalSerializationApi::class)
-	override suspend fun persist(events: Flow<EVENT>): Flow<EVENT> {
+	override fun persist(events: Flow<EVENT>): Flow<EVENT> {
 		val toSave: Flow<EventSourcing<ID>>  = events.map { event ->
 			val encoded: String=  json.encodeToString(eventType.serializer(), event)
 			EventSourcing(

--- a/s2-spring/sourcing/s2-spring-boot-starter-sourcing-data-mongodb/src/test/kotlin/s2/spring/sourcing/data/mongodb/MongoEventRepositoryTest.kt
+++ b/s2-spring/sourcing/s2-spring-boot-starter-sourcing-data-mongodb/src/test/kotlin/s2/spring/sourcing/data/mongodb/MongoEventRepositoryTest.kt
@@ -1,0 +1,75 @@
+package s2.spring.sourcing.data.mongodb
+
+import java.util.UUID
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.toList
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.data.mongodb.core.ReactiveMongoOperations
+import s2.dsl.automate.Evt
+import s2.dsl.automate.model.WithS2Id
+import s2.sourcing.dsl.event.EventRepository
+import s2.spring.sourcing.data.mongodb.config.SpringTestBase
+
+@Serializable
+data class TestEvent(
+    val id: String,
+    val name: String,
+    val timestamp: Long = System.currentTimeMillis()
+) : Evt, WithS2Id<String> {
+    override fun s2Id() = id
+}
+
+class MongoEventRepositoryTest : SpringTestBase() {
+
+    @Autowired
+    private lateinit var mongoOperations: ReactiveMongoOperations
+
+    private lateinit var eventRepository: EventRepository<TestEvent, String>
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    @BeforeEach
+    suspend fun setup() {
+        eventRepository = MongoEventRepositoryFactory(mongoOperations)
+            .create(TestEvent::class, json)
+        eventRepository.createTable() // no-op for Mongo
+        // Clean up any previously persisted documents.
+        mongoOperations.dropCollection("eventSourcing").block()
+    }
+
+    @Test
+    suspend fun `persist single event and load it back by object id (encode-decode round-trip)`() {
+        val objId = UUID.randomUUID().toString()
+        val event = TestEvent(id = objId, name = "Created")
+
+        val persisted = eventRepository.persist(event)
+        assertThat(persisted).isEqualTo(event)
+
+        val loaded = eventRepository.load(objId).toList()
+        assertThat(loaded).containsExactly(event)
+    }
+
+    @Test
+    suspend fun `persist a flow of events and load all back`() {
+        val objId1 = UUID.randomUUID().toString()
+        val objId2 = UUID.randomUUID().toString()
+
+        val event1 = TestEvent(id = objId1, name = "Event 1", timestamp = 100)
+        val event2 = TestEvent(id = objId1, name = "Event 2", timestamp = 200)
+        val event3 = TestEvent(id = objId2, name = "Event 3", timestamp = 150)
+
+        val returned = eventRepository.persist(flowOf(event1, event2, event3)).toList()
+        assertThat(returned).containsExactlyInAnyOrder(event1, event2, event3)
+
+        val allEvents = eventRepository.loadAll().toList()
+        assertThat(allEvents).containsExactlyInAnyOrder(event1, event2, event3)
+
+        val forObj1 = eventRepository.load(objId1).toList()
+        assertThat(forObj1).containsExactlyInAnyOrder(event1, event2)
+    }
+}

--- a/s2-spring/sourcing/s2-spring-boot-starter-sourcing-data-mongodb/src/test/kotlin/s2/spring/sourcing/data/mongodb/config/ContainersConfig.kt
+++ b/s2-spring/sourcing/s2-spring-boot-starter-sourcing-data-mongodb/src/test/kotlin/s2/spring/sourcing/data/mongodb/config/ContainersConfig.kt
@@ -1,0 +1,20 @@
+package s2.spring.sourcing.data.mongodb.config
+
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection
+import org.springframework.context.annotation.Bean
+import org.testcontainers.containers.MongoDBContainer
+
+@TestConfiguration(proxyBeanMethods = false)
+open class ContainersConfig {
+
+    companion object {
+        const val MONGO_IMAGE: String = "mongo:7.0"
+    }
+
+    @Bean
+    @ServiceConnection
+    open fun mongo(): MongoDBContainer {
+        return MongoDBContainer(MONGO_IMAGE)
+    }
+}

--- a/s2-spring/sourcing/s2-spring-boot-starter-sourcing-data-mongodb/src/test/kotlin/s2/spring/sourcing/data/mongodb/config/SpringTestBase.kt
+++ b/s2-spring/sourcing/s2-spring-boot-starter-sourcing-data-mongodb/src/test/kotlin/s2/spring/sourcing/data/mongodb/config/SpringTestBase.kt
@@ -1,0 +1,13 @@
+package s2.spring.sourcing.data.mongodb.config
+
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.annotation.Import
+import org.springframework.test.context.junit.jupiter.SpringExtension
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@ExtendWith(SpringExtension::class)
+@Import(ContainersConfig::class)
+@SpringBootTest(classes = [TestApplication::class])
+abstract class SpringTestBase

--- a/s2-spring/sourcing/s2-spring-boot-starter-sourcing-data-mongodb/src/test/kotlin/s2/spring/sourcing/data/mongodb/config/TestApplication.kt
+++ b/s2-spring/sourcing/s2-spring-boot-starter-sourcing-data-mongodb/src/test/kotlin/s2/spring/sourcing/data/mongodb/config/TestApplication.kt
@@ -1,0 +1,19 @@
+package s2.spring.sourcing.data.mongodb.config
+
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.runApplication
+import org.springframework.data.mongodb.repository.config.EnableReactiveMongoRepositories
+
+/**
+ * [EnableReactiveMongoRepositories] registers the reactive/coroutine repository
+ * infrastructure so the generic [s2.spring.sourcing.data.mongodb.SpringDataEventRepository]
+ * built manually by [s2.spring.sourcing.data.mongodb.MongoEventRepositoryFactory] bridges
+ * the coroutine CRUD methods (save/findAll/count) to their reactive equivalents.
+ */
+@EnableReactiveMongoRepositories(basePackages = ["s2.spring.sourcing.data.mongodb"])
+@SpringBootApplication
+open class TestApplication
+
+fun main(args: Array<String>) {
+    runApplication<TestApplication>(*args)
+}

--- a/s2-spring/sourcing/s2-spring-boot-starter-sourcing-data-r2dbc/src/main/kotlin/s2/spring/sourcing/data/r2dbc/R2dbcEventRepository.kt
+++ b/s2-spring/sourcing/s2-spring-boot-starter-sourcing-data-r2dbc/src/main/kotlin/s2/spring/sourcing/data/r2dbc/R2dbcEventRepository.kt
@@ -21,8 +21,6 @@ import s2.dsl.automate.model.WithS2Id
 import s2.sourcing.dsl.event.EventRepository
 import s2.spring.sourcing.data.event.EventSourcing
 
-// S6309: the suspend modifier is mandated by the EventRepository contract (published API).
-@Suppress("kotlin:S6309")
 class R2dbcEventRepository<EVENT, ID>(
 	private val json: Json,
 	private val databaseClient: DatabaseClient,
@@ -46,7 +44,7 @@ EVENT: WithS2Id<ID>
 			.then(Mono.just(Unit))
 	}
 
-	override suspend fun load(id: ID): Flow<EVENT> {
+	override fun load(id: ID): Flow<EVENT> {
 		val query = Query
 			.query(Criteria.where("obj_id").`is`(id!!))
 			.sort(sortByCreatedDate)
@@ -56,7 +54,7 @@ EVENT: WithS2Id<ID>
 			.flow().toEvents()
 	}
 
-	override suspend fun loadAll(): Flow<EVENT> {
+	override fun loadAll(): Flow<EVENT> {
 		val query = Query.query(Criteria.empty()).sort(sortByCreatedDate)
 			.sort(sortByCreatedDate)
 		return r2dbcEntityTemplate.select(EventSourcing::class.java)
@@ -66,7 +64,7 @@ EVENT: WithS2Id<ID>
 	}
 
 	@OptIn(InternalSerializationApi::class)
-	override suspend fun persist(events: Flow<EVENT>): Flow<EVENT> {
+	override fun persist(events: Flow<EVENT>): Flow<EVENT> {
 		return events.map { event ->
 			val encoded =  json.encodeToString(eventType.serializer(), event)
 			r2dbcEntityTemplate.insert(EventSourcing::class.java)

--- a/s2-spring/sourcing/s2-spring-boot-starter-sourcing-data-r2dbc/src/test/kotlin/s2/spring/sourcing/data/r2dbc/R2dbcEventRepositoryTest.kt
+++ b/s2-spring/sourcing/s2-spring-boot-starter-sourcing-data-r2dbc/src/test/kotlin/s2/spring/sourcing/data/r2dbc/R2dbcEventRepositoryTest.kt
@@ -2,6 +2,7 @@ package s2.spring.sourcing.data.r2dbc
 
 import java.util.UUID
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.toList
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
@@ -108,5 +109,24 @@ class R2dbcEventRepositoryTest : SpringTestBase() {
         assertThat(loadedEvents[0].name).isEqualTo("Event 1")
         assertThat(loadedEvents[1].name).isEqualTo("Event 3")
         assertThat(loadedEvents[2].name).isEqualTo("Event 2")
+    }
+
+    @Test
+    suspend fun `should persist a cold flow of events and load them back`() {
+        // Given
+        val objId = UUID.randomUUID().toString()
+        val event1 = TestEvent(id = objId, name = "Flow 1", timestamp = 100)
+        val event2 = TestEvent(id = objId, name = "Flow 2", timestamp = 200)
+
+        // When - persist via the Flow overload (the de-suspended cold-flow branch)
+        val returned = eventRepository.persist(flowOf(event1, event2)).toList()
+
+        // Then - the flow echoes the decoded events
+        assertThat(returned).containsExactlyInAnyOrder(event1, event2)
+
+        // And they are retrievable
+        val loadedEvents = eventRepository.load(objId).toList()
+        assertThat(loadedEvents).hasSize(2)
+        assertThat(loadedEvents.map { it.name }).containsExactlyInAnyOrder("Flow 1", "Flow 2")
     }
 }

--- a/s2-spring/sourcing/s2-spring-boot-starter-sourcing-data/build.gradle.kts
+++ b/s2-spring/sourcing/s2-spring-boot-starter-sourcing-data/build.gradle.kts
@@ -8,6 +8,7 @@ dependencies {
 	api(project(":s2-spring:sourcing:s2-spring-boot-starter-sourcing"))
 	api(project(":s2-spring:utils:s2-spring-boot-starter-utils-data"))
 	implementation(libs.spring.boot.autoconfigure)
+	implementation(libs.bundles.kserialization.json)
 	kapt(libs.spring.boot.configuration.processor)
 	implementation(libs.bundles.spring.data.commons)
 }

--- a/s2-spring/sourcing/s2-spring-boot-starter-sourcing/build.gradle.kts
+++ b/s2-spring/sourcing/s2-spring-boot-starter-sourcing/build.gradle.kts
@@ -9,4 +9,6 @@ dependencies {
 	implementation(libs.spring.tx)
 	implementation(libs.spring.boot.autoconfigure)
 	kapt(libs.spring.boot.configuration.processor)
+
+	testImplementation(libs.bundles.test.junit)
 }

--- a/s2-spring/sourcing/s2-spring-boot-starter-sourcing/src/main/kotlin/s2/spring/automate/sourcing/S2AutomateDeciderSpring.kt
+++ b/s2-spring/sourcing/s2-spring-boot-starter-sourcing/src/main/kotlin/s2/spring/automate/sourcing/S2AutomateDeciderSpring.kt
@@ -14,9 +14,8 @@ import s2.sourcing.dsl.Decide
 import s2.sourcing.dsl.Loader
 import s2.sourcing.dsl.event.EventRepository
 
-// S6309: the suspend modifier is mandated by the S2AutomateSourcingDecider contract (published API).
 // S6514: interface delegation with "by" is impossible, the engine is injected after construction.
-@Suppress("kotlin:S6309", "kotlin:S6514")
+@Suppress("kotlin:S6514")
 open class S2AutomateDeciderSpring<ENTITY, STATE, EVENT, ID> : S2AutomateSourcingDecider<ENTITY, STATE, EVENT, ID> where
 STATE : S2State,
 EVENT : Evt,
@@ -57,8 +56,8 @@ ENTITY : WithS2State<STATE> {
 		fnc: suspend (t: COMMAND, entity: ENTITY) -> EVENT_OUT
 	): Decide<COMMAND, EVENT_OUT> = engine.decide(fnc)
 
-	suspend fun loadAll() = engine.loadAll()
-	suspend fun load(id: ID) = engine.load(id)
+	fun loadAll() = engine.loadAll()
+	fun load(id: ID) = engine.load(id)
 
 	override suspend fun replayHistory() = engine.replayHistory()
 }

--- a/s2-spring/sourcing/s2-spring-boot-starter-sourcing/src/main/kotlin/s2/spring/automate/sourcing/persist/S2AutomateSourcingPersister.kt
+++ b/s2-spring/sourcing/s2-spring-boot-starter-sourcing/src/main/kotlin/s2/spring/automate/sourcing/persist/S2AutomateSourcingPersister.kt
@@ -17,8 +17,6 @@ import s2.dsl.automate.model.WithS2State
 import s2.sourcing.dsl.Loader
 import s2.sourcing.dsl.event.EventRepository
 
-// S6309: the suspend modifier is mandated by the AutomatePersister contract (published API).
-@Suppress("kotlin:S6309")
 class S2AutomateSourcingPersister<STATE, ID, ENTITY, EVENT>(
     private val projectionLoader: Loader<EVENT, ENTITY, ID>,
     private val eventStore: EventRepository<EVENT, ID>,
@@ -34,13 +32,13 @@ EVENT: WithS2Id<ID> {
         return load(automateContexts, flowOf(id)).firstOrNull()
     }
 
-    override suspend fun load(automateContexts: AutomateContext<S2Automate>, ids: Flow<ID & Any>): Flow<ENTITY?> {
+    override fun load(automateContexts: AutomateContext<S2Automate>, ids: Flow<ID & Any>): Flow<ENTITY?> {
         return ids.map { id ->
             projectionLoader.load(id)
         }
     }
 
-    override suspend fun persistInit(
+    override fun persistInit(
         transitionContexts: Flow<InitTransitionAppliedContext<STATE, ID, ENTITY, EVENT, S2Automate>>
     ): Flow<EVENT> {
         return transitionContexts.map {
@@ -50,7 +48,7 @@ EVENT: WithS2Id<ID> {
         }
     }
 
-    override suspend fun persist(
+    override fun persist(
         transitionContexts: Flow<TransitionAppliedContext<STATE, ID, ENTITY, EVENT, S2Automate>>
     ): Flow<EVENT> {
         return transitionContexts.map {
@@ -59,7 +57,7 @@ EVENT: WithS2Id<ID> {
             .map { it.second }
     }
 
-    private suspend fun Flow<EVENT>.persistEvent(): Flow<Pair<ENTITY, EVENT>> {
+    private fun Flow<EVENT>.persistEvent(): Flow<Pair<ENTITY, EVENT>> {
         return eventStore
             .persist(this)
             .map { event ->

--- a/s2-spring/sourcing/s2-spring-boot-starter-sourcing/src/test/kotlin/s2/spring/automate/sourcing/S2AutomateDeciderSpringTest.kt
+++ b/s2-spring/sourcing/s2-spring-boot-starter-sourcing/src/test/kotlin/s2/spring/automate/sourcing/S2AutomateDeciderSpringTest.kt
@@ -4,6 +4,7 @@ import f2.dsl.cqrs.envelope.Envelope
 import f2.dsl.cqrs.enveloped.EnvelopedFlow
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.toList
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import s2.automate.core.appevent.publisher.AppEventPublisher
@@ -139,5 +140,42 @@ class S2AutomateDeciderSpringTest {
         val result = decider.transition(DoCmd("id1")) { TestEvent("ignored") }
 
         assertThat(result).isSameAs(sentinel)
+    }
+
+    /** Decider backed by a real (no-op-fed) sourcing engine, to exercise the delegating builders. */
+    private fun deciderWithRealEngine(): S2AutomateDeciderSpring<TestEntity, TestState, TestEvent, String> {
+        val decider = object : S2AutomateDeciderSpring<TestEntity, TestState, TestEvent, String>() {}
+        injectEngine(decider, S2AutomateSourcingDeciderImpl(NoOpEngine, NoOpPublisher, NoOpLoader, NoOpEventStore))
+        return decider
+    }
+
+    @Test
+    suspend fun `init builder returns a Decide delegating to the engine`() {
+        val decide = deciderWithRealEngine().init<TestEvent, CreateCmd> { TestEvent("e") }
+        assertThat(decide).isNotNull
+    }
+
+    @Test
+    suspend fun `decide from init command returns a Decide delegating to the engine`() {
+        val decide = deciderWithRealEngine().decide<TestEvent, CreateCmd> { TestEvent("e") }
+        assertThat(decide).isNotNull
+    }
+
+    @Test
+    suspend fun `decide from transition command returns a Decide delegating to the engine`() {
+        val decide = deciderWithRealEngine().decide<TestEvent, DoCmd> { _, _ -> TestEvent("e") }
+        assertThat(decide).isNotNull
+    }
+
+    @Test
+    suspend fun `loadAll and load delegate to the event store`() {
+        val decider = deciderWithRealEngine()
+        assertThat(decider.loadAll().toList()).isEmpty()
+        assertThat(decider.load("id1").toList()).isEmpty()
+    }
+
+    @Test
+    suspend fun `replayHistory delegates to the engine`() {
+        deciderWithRealEngine().replayHistory()
     }
 }

--- a/s2-spring/sourcing/s2-spring-boot-starter-sourcing/src/test/kotlin/s2/spring/automate/sourcing/S2AutomateDeciderSpringTest.kt
+++ b/s2-spring/sourcing/s2-spring-boot-starter-sourcing/src/test/kotlin/s2/spring/automate/sourcing/S2AutomateDeciderSpringTest.kt
@@ -1,0 +1,143 @@
+package s2.spring.automate.sourcing
+
+import f2.dsl.cqrs.envelope.Envelope
+import f2.dsl.cqrs.enveloped.EnvelopedFlow
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import s2.automate.core.appevent.publisher.AppEventPublisher
+import s2.automate.core.engine.S2AutomateEngine
+import s2.automate.core.sourcing.S2AutomateSourcingDeciderImpl
+import s2.dsl.automate.Evt
+import s2.dsl.automate.S2Command
+import s2.dsl.automate.S2InitCommand
+import s2.dsl.automate.S2State
+import s2.dsl.automate.model.WithS2Id
+import s2.dsl.automate.model.WithS2State
+import s2.sourcing.dsl.Loader
+import s2.sourcing.dsl.event.EventRepository
+
+/**
+ * Unit tests for [S2AutomateDeciderSpring] verifying that:
+ *  - withContext wires a concrete engine,
+ *  - init / transition delegate to the injected engine.
+ */
+class S2AutomateDeciderSpringTest {
+
+    // ---- domain fixtures ----
+
+    enum class TestState(override var position: Int) : S2State {
+        Created(0)
+    }
+
+    data class TestEntity(val id: String) : WithS2Id<String>, WithS2State<TestState> {
+        override fun s2Id(): String = id
+        override fun s2State(): TestState = TestState.Created
+    }
+
+    data class TestEvent(val id: String) : Evt, WithS2Id<String> {
+        override fun s2Id(): String = id
+    }
+
+    data class CreateCmd(val id: String) : S2InitCommand
+    data class DoCmd(override val id: String) : S2Command<String>
+
+    // ---- no-op collaborators (never actually driven) ----
+
+    private object NoOpEngine : S2AutomateEngine<TestState, TestEntity, String, TestEvent> {
+        override fun <COMMAND : S2InitCommand, ENTITY_OUT : TestEntity, EVENT_OUT : TestEvent> create(
+            commands: EnvelopedFlow<COMMAND>,
+            decide: suspend (cmd: Envelope<COMMAND>) -> Pair<ENTITY_OUT, Envelope<EVENT_OUT>>
+        ): EnvelopedFlow<EVENT_OUT> = flowOf()
+
+        override fun <COMMAND : S2Command<String>, ENTITY_OUT : TestEntity, EVENT_OUT : TestEvent> doTransition(
+            commands: EnvelopedFlow<COMMAND>,
+            exec: suspend (Envelope<out COMMAND>, TestEntity) -> Pair<ENTITY_OUT, Envelope<EVENT_OUT>>
+        ): EnvelopedFlow<EVENT_OUT> = flowOf()
+    }
+
+    private object NoOpPublisher : AppEventPublisher {
+        override fun <EVENT> publish(event: EVENT & Any) = Unit
+    }
+
+    private object NoOpLoader : Loader<TestEvent, TestEntity, String> {
+        override suspend fun load(id: String): TestEntity? = null
+        override suspend fun load(events: Flow<TestEvent>): TestEntity? = null
+        override suspend fun loadAndEvolve(id: String, news: Flow<TestEvent>): TestEntity? = null
+        override suspend fun evolve(events: Flow<TestEvent>, entity: TestEntity?): TestEntity? = null
+        override suspend fun reloadHistory(): List<TestEntity> = emptyList()
+    }
+
+    private object NoOpEventStore : EventRepository<TestEvent, String> {
+        override fun load(id: String): Flow<TestEvent> = flowOf()
+        override fun loadAll(): Flow<TestEvent> = flowOf()
+        override suspend fun persist(event: TestEvent): TestEvent = event
+        override fun persist(events: Flow<TestEvent>): Flow<TestEvent> = events
+        override suspend fun createTable() = Unit
+    }
+
+    /** Engine whose init/transition return a controlled sentinel event. */
+    private class StubEngine(
+        private val sentinel: TestEvent,
+    ) : S2AutomateSourcingDeciderImpl<TestState, TestEntity, String, TestEvent>(
+        NoOpEngine, NoOpPublisher, NoOpLoader, NoOpEventStore
+    ) {
+        override suspend fun <EVENT_OUT : TestEvent> init(
+            command: S2InitCommand,
+            buildEvent: suspend () -> EVENT_OUT
+        ): EVENT_OUT {
+            @Suppress("UNCHECKED_CAST")
+            return sentinel as EVENT_OUT
+        }
+
+        override suspend fun <EVENT_OUT : TestEvent> transition(
+            command: S2Command<String>,
+            exec: suspend TestEntity.() -> EVENT_OUT
+        ): EVENT_OUT {
+            @Suppress("UNCHECKED_CAST")
+            return sentinel as EVENT_OUT
+        }
+    }
+
+    private fun injectEngine(
+        decider: S2AutomateDeciderSpring<TestEntity, TestState, TestEvent, String>,
+        engine: S2AutomateSourcingDeciderImpl<TestState, TestEntity, String, TestEvent>,
+    ) {
+        S2AutomateDeciderSpring::class.java
+            .getDeclaredField("engine")
+            .apply { isAccessible = true }
+            .set(decider, engine)
+    }
+
+    // ---- tests ----
+
+    @Test
+    suspend fun `withContext builds a concrete sourcing engine`() {
+        val decider = object : S2AutomateDeciderSpring<TestEntity, TestState, TestEvent, String>() {}
+        // Should not throw: constructs the underlying S2AutomateSourcingDeciderImpl.
+        decider.withContext(NoOpEngine, NoOpPublisher, NoOpLoader, NoOpEventStore)
+    }
+
+    @Test
+    suspend fun `init delegates to the engine`() {
+        val decider = object : S2AutomateDeciderSpring<TestEntity, TestState, TestEvent, String>() {}
+        val sentinel = TestEvent("init-sentinel")
+        injectEngine(decider, StubEngine(sentinel))
+
+        val result = decider.init(CreateCmd("id1")) { TestEvent("ignored") }
+
+        assertThat(result).isSameAs(sentinel)
+    }
+
+    @Test
+    suspend fun `transition delegates to the engine`() {
+        val decider = object : S2AutomateDeciderSpring<TestEntity, TestState, TestEvent, String>() {}
+        val sentinel = TestEvent("transition-sentinel")
+        injectEngine(decider, StubEngine(sentinel))
+
+        val result = decider.transition(DoCmd("id1")) { TestEvent("ignored") }
+
+        assertThat(result).isSameAs(sentinel)
+    }
+}

--- a/s2-spring/sourcing/s2-spring-boot-starter-sourcing/src/test/kotlin/s2/spring/automate/sourcing/persist/S2AutomateSourcingPersisterTest.kt
+++ b/s2-spring/sourcing/s2-spring-boot-starter-sourcing/src/test/kotlin/s2/spring/automate/sourcing/persist/S2AutomateSourcingPersisterTest.kt
@@ -1,0 +1,158 @@
+package s2.spring.automate.sourcing.persist
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.toList
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import s2.automate.core.config.S2BatchProperties
+import s2.automate.core.context.AutomateContext
+import s2.automate.core.context.InitTransitionAppliedContext
+import s2.automate.core.context.TransitionAppliedContext
+import s2.automate.core.storing.snap.SnapPersister
+import s2.dsl.automate.Evt
+import s2.dsl.automate.S2Automate
+import s2.dsl.automate.S2Command
+import s2.dsl.automate.S2InitCommand
+import s2.dsl.automate.S2State
+import s2.dsl.automate.builder.s2
+import s2.dsl.automate.model.WithS2Id
+import s2.dsl.automate.model.WithS2State
+import s2.sourcing.dsl.Loader
+import s2.sourcing.dsl.event.EventRepository
+
+/**
+ * Unit tests for [S2AutomateSourcingPersister] exercising the (de-suspended)
+ * cold-flow load/loadAll/persist paths with in-memory fakes. No Spring / DB.
+ */
+class S2AutomateSourcingPersisterTest {
+
+    // ---- domain fixtures ----
+
+    enum class TestState(override var position: Int) : S2State {
+        Created(0)
+    }
+
+    data class TestEntity(val id: String) : WithS2Id<String>, WithS2State<TestState> {
+        override fun s2Id(): String = id
+        override fun s2State(): TestState = TestState.Created
+    }
+
+    data class TestEvent(val id: String) : Evt, WithS2Id<String> {
+        override fun s2Id(): String = id
+    }
+
+    data class StubInitCmd(val id: String) : S2InitCommand
+    data class StubCmd(override val id: String) : S2Command<String>
+
+    private val automate: S2Automate = s2 { name = "SourcingPersisterTest" }
+    private val automateContext = AutomateContext(automate, S2BatchProperties())
+
+    // ---- fakes ----
+
+    /** Echoes every persisted event back; records what was persisted. */
+    private class FakeEventRepository : EventRepository<TestEvent, String> {
+        val persisted = mutableListOf<TestEvent>()
+
+        override fun load(id: String): Flow<TestEvent> = flowOf()
+        override fun loadAll(): Flow<TestEvent> = flowOf()
+
+        override suspend fun persist(event: TestEvent): TestEvent {
+            persisted.add(event)
+            return event
+        }
+
+        override fun persist(events: Flow<TestEvent>): Flow<TestEvent> = events.map { event ->
+            persisted.add(event)
+            event
+        }
+
+        override suspend fun createTable() = Unit
+    }
+
+    /** Rebuilds an entity from the event id. */
+    private class FakeLoader : Loader<TestEvent, TestEntity, String> {
+        override suspend fun load(id: String): TestEntity? = TestEntity(id)
+        override suspend fun load(events: Flow<TestEvent>): TestEntity? =
+            events.toList().lastOrNull()?.let { TestEntity(it.id) }
+        override suspend fun loadAndEvolve(id: String, news: Flow<TestEvent>): TestEntity? =
+            TestEntity(id)
+        override suspend fun evolve(events: Flow<TestEvent>, entity: TestEntity?): TestEntity? =
+            events.toList().lastOrNull()?.let { TestEntity(it.id) }
+        override suspend fun reloadHistory(): List<TestEntity> = emptyList()
+    }
+
+    private fun persister(
+        loader: Loader<TestEvent, TestEntity, String> = FakeLoader(),
+        eventStore: FakeEventRepository = FakeEventRepository(),
+    ): S2AutomateSourcingPersister<TestState, String, TestEntity, TestEvent> {
+        val snapPersister = SnapPersister<TestState, String, TestEntity, TestEvent>(
+            projectionLoader = loader,
+            snapRepository = null,
+            retryTaskChannel = null,
+        )
+        return S2AutomateSourcingPersister(
+            projectionLoader = loader,
+            eventStore = eventStore,
+            snapPersister = snapPersister,
+        )
+    }
+
+    private fun initCtx(id: String) =
+        InitTransitionAppliedContext<TestState, String, TestEntity, TestEvent, S2Automate>(
+            automateContext = automateContext,
+            msgId = id,
+            msg = StubInitCmd(id),
+            event = TestEvent(id),
+            entity = TestEntity(id),
+        )
+
+    private fun transitionCtx(id: String) =
+        TransitionAppliedContext<TestState, String, TestEntity, TestEvent, S2Automate>(
+            automateContext = automateContext,
+            msgId = id,
+            from = TestState.Created,
+            msg = StubCmd(id),
+            event = TestEvent(id),
+            entity = TestEntity(id),
+        )
+
+    // ---- tests ----
+
+    @Test
+    suspend fun `load(id) delegates to the projection loader`() {
+        val entity = persister().load(automateContext, "obj-1")
+        assertThat(entity).isEqualTo(TestEntity("obj-1"))
+    }
+
+    @Test
+    suspend fun `load(ids) maps each id through the projection loader`() {
+        val loaded = persister()
+            .load(automateContext, flowOf("a", "b", "c"))
+            .toList()
+        assertThat(loaded).containsExactly(TestEntity("a"), TestEntity("b"), TestEntity("c"))
+    }
+
+    @Test
+    suspend fun `persistInit persists events through the event store and returns them`() {
+        val store = FakeEventRepository()
+        val events = persister(eventStore = store)
+            .persistInit(flowOf(initCtx("e1"), initCtx("e2")))
+            .toList()
+
+        assertThat(events).containsExactly(TestEvent("e1"), TestEvent("e2"))
+        assertThat(store.persisted).containsExactly(TestEvent("e1"), TestEvent("e2"))
+    }
+
+    @Test
+    suspend fun `persist persists transition events through the event store and returns them`() {
+        val store = FakeEventRepository()
+        val events = persister(eventStore = store)
+            .persist(flowOf(transitionCtx("t1"), transitionCtx("t2")))
+            .toList()
+
+        assertThat(events).containsExactly(TestEvent("t1"), TestEvent("t2"))
+        assertThat(store.persisted).containsExactly(TestEvent("t1"), TestEvent("t2"))
+    }
+}

--- a/s2-spring/storing/s2-spring-boot-starter-storing-data/src/main/kotlin/s2/spring/automate/data/persister/SpringDataAutomateCoroutinePersisterFlow.kt
+++ b/s2-spring/storing/s2-spring-boot-starter-storing-data/src/main/kotlin/s2/spring/automate/data/persister/SpringDataAutomateCoroutinePersisterFlow.kt
@@ -18,8 +18,6 @@ import s2.dsl.automate.S2State
 import s2.dsl.automate.model.WithS2Id
 import s2.dsl.automate.model.WithS2State
 
-// S6309: the suspend modifier is mandated by the AutomatePersister contract (published API).
-@Suppress("kotlin:S6309")
 class SpringDataAutomateCoroutinePersisterFlow<STATE, ID: Any, ENTITY, EVENT>(
 	private val repository: CoroutineCrudRepository<ENTITY, ID>,
 	private val batchParams: S2BatchProperties,
@@ -33,12 +31,12 @@ ENTITY : WithS2Id<ID> {
 		return load(automateContexts, flowOf(id)).firstOrNull()
 	}
 
-	override suspend fun load(automateContexts: AutomateContext<S2Automate>, ids: Flow<ID>): Flow<ENTITY> {
+	override fun load(automateContexts: AutomateContext<S2Automate>, ids: Flow<ID>): Flow<ENTITY> {
 		return repository.findAllById(ids)
 	}
 
 
-	override suspend fun persistInit(
+	override fun persistInit(
 		transitionContexts: Flow<InitTransitionAppliedContext<STATE, ID, ENTITY, EVENT, S2Automate>>
 	): Flow<EVENT> {
 		return transitionContexts.batch(batchParams.asBatch()) { context ->
@@ -49,7 +47,7 @@ ENTITY : WithS2Id<ID> {
 		}
 	}
 
-	override suspend fun persist(
+	override fun persist(
 		transitionContexts: Flow<TransitionAppliedContext<STATE, ID, ENTITY, EVENT, S2Automate>>
 	): Flow<EVENT> = flow {
 		val entities = mutableListOf<ENTITY>()

--- a/s2-spring/storing/s2-spring-boot-starter-storing-data/src/main/kotlin/s2/spring/automate/data/persister/SpringDataAutomatePersisterFlow.kt
+++ b/s2-spring/storing/s2-spring-boot-starter-storing-data/src/main/kotlin/s2/spring/automate/data/persister/SpringDataAutomatePersisterFlow.kt
@@ -2,7 +2,9 @@ package s2.spring.automate.data.persister
 
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.toList
@@ -16,8 +18,6 @@ import s2.dsl.automate.S2State
 import s2.dsl.automate.model.WithS2Id
 import s2.dsl.automate.model.WithS2State
 
-// S6309: the suspend modifier is mandated by the AutomatePersister contract (published API).
-@Suppress("kotlin:S6309")
 class SpringDataAutomatePersisterFlow<STATE, ID: Any, ENTITY, EVENT>(
 	private val repository: CrudRepository<ENTITY, ID>,
 ) : AutomatePersister<STATE, ID, ENTITY, EVENT, S2Automate> where
@@ -30,11 +30,11 @@ ENTITY : WithS2Id<ID> {
 		return load(automateContexts, flowOf(id)).firstOrNull()
 	}
 
-	override suspend fun load(automateContext: AutomateContext<S2Automate>, ids: Flow<ID>): Flow<ENTITY> {
-		return repository.findAllById(ids.toList()).asFlow()
+	override fun load(automateContext: AutomateContext<S2Automate>, ids: Flow<ID>): Flow<ENTITY> = flow {
+		emitAll(repository.findAllById(ids.toList()).asFlow())
 	}
 
-	override suspend fun persistInit(
+	override fun persistInit(
 		transitionContext: Flow<InitTransitionAppliedContext<STATE, ID, ENTITY, EVENT, S2Automate>>
 	): Flow<EVENT> {
 		return transitionContext.map {
@@ -43,15 +43,12 @@ ENTITY : WithS2Id<ID> {
 		}
 	}
 
-	override suspend fun persist(
+	override fun persist(
 		transitionContext: Flow<TransitionAppliedContext<STATE, ID, ENTITY, EVENT, S2Automate>>
-	): Flow<EVENT> {
-		val eventsFlow: Flow<EVENT> = transitionContext.map { it.event }
-
-		val entitiesFlow: Flow<ENTITY> = transitionContext.map { it.entity }
-		repository.saveAll(entitiesFlow.toList())
-
-		return eventsFlow
+	): Flow<EVENT> = flow {
+		val contexts = transitionContext.toList()
+		repository.saveAll(contexts.map { it.entity })
+		contexts.forEach { emit(it.event) }
 	}
 
 }

--- a/s2-spring/storing/s2-spring-boot-starter-storing-data/src/main/kotlin/s2/spring/automate/data/persister/SpringDataAutomateReactivePersisterFlow.kt
+++ b/s2-spring/storing/s2-spring-boot-starter-storing-data/src/main/kotlin/s2/spring/automate/data/persister/SpringDataAutomateReactivePersisterFlow.kt
@@ -20,8 +20,6 @@ import s2.dsl.automate.S2State
 import s2.dsl.automate.model.WithS2Id
 import s2.dsl.automate.model.WithS2State
 
-// S6309: the suspend modifier is mandated by the AutomatePersister contract (published API).
-@Suppress("kotlin:S6309")
 class SpringDataAutomateReactivePersisterFlow<STATE, ID: Any, ENTITY, EVENT>(
 	private val repository: ReactiveCrudRepository<ENTITY, ID>,
 	private val batchParams: S2BatchProperties,
@@ -36,11 +34,11 @@ ENTITY : WithS2Id<ID> {
 		return load(automateContexts, flowOf(id)).firstOrNull()
 	}
 
-	override suspend fun load(automateContexts: AutomateContext<S2Automate>, ids: Flow<ID>): Flow<ENTITY> {
+	override fun load(automateContexts: AutomateContext<S2Automate>, ids: Flow<ID>): Flow<ENTITY> {
 		return repository.findAllById(ids.asFlux()).asFlow()
 	}
 
-	override suspend fun persistInit(
+	override fun persistInit(
 		transitionContexts: Flow<InitTransitionAppliedContext<STATE, ID, ENTITY, EVENT, S2Automate>>
 	): Flow<EVENT> {
 		return transitionContexts.batch(batchParams.asBatch()) { contexts ->
@@ -50,7 +48,7 @@ ENTITY : WithS2Id<ID> {
 			events
 		}
 	}
-	override suspend fun persist(
+	override fun persist(
 		transitionContexts: Flow<TransitionAppliedContext<STATE, ID, ENTITY, EVENT, S2Automate>>
 	): Flow<EVENT> {
 		return transitionContexts.batch(batchParams.asBatch()) { contexts ->

--- a/s2-spring/storing/s2-spring-boot-starter-storing/src/main/kotlin/s2/spring/automate/executor/S2AutomateExecutorSpring.kt
+++ b/s2-spring/storing/s2-spring-boot-starter-storing/src/main/kotlin/s2/spring/automate/executor/S2AutomateExecutorSpring.kt
@@ -28,9 +28,8 @@ import s2.sourcing.dsl.Decide
  * @param ID The identifier type of the entity.
  * @param ENTITY The entity type.
  */
-// S6309: the suspend modifier is mandated by the S2AutomateStoringEvolver contracts (published API).
 // S6514: interface delegation with "by" is impossible, the engine is injected after construction.
-@Suppress("kotlin:S6309", "kotlin:S6514")
+@Suppress("kotlin:S6514")
 open class S2AutomateExecutorSpring<STATE, ID, ENTITY> :
     S2AutomateStoringEvolver<STATE, ID, ENTITY, Evt>,
     S2AutomateStoringEvolverFlow<STATE, ID, ENTITY, Evt>
@@ -99,7 +98,7 @@ open class S2AutomateExecutorSpring<STATE, ID, ENTITY> :
      * @param build The function to build the entity and event.
      * @return The flow of created events.
      */
-    override suspend fun <COMMAND : S2InitCommand, EVENT_OUT : Evt> evolve(
+    override fun <COMMAND : S2InitCommand, EVENT_OUT : Evt> evolve(
         commands: Flow<COMMAND>,
         build: suspend (cmd: COMMAND) -> Pair<ENTITY, EVENT_OUT>
     ): Flow<EVENT_OUT> = engine.evolve(commands, build)
@@ -111,7 +110,7 @@ open class S2AutomateExecutorSpring<STATE, ID, ENTITY> :
      * @param exec The function to execute the transitions.
      * @return The flow of resulting events.
      */
-    override suspend fun <COMMAND : S2Command<ID>, EVENT_OUT : Evt> evolve(
+    override fun <COMMAND : S2Command<ID>, EVENT_OUT : Evt> evolve(
         commands: Flow<COMMAND>,
         exec: suspend (COMMAND, ENTITY) -> Pair<ENTITY, EVENT_OUT>
     ): Flow<EVENT_OUT> = engine.evolve(commands, exec)
@@ -124,23 +123,23 @@ open class S2AutomateExecutorSpring<STATE, ID, ENTITY> :
         build: suspend (cmd: COMMAND) -> Pair<ENTITY, EVENT_OUT>
     ): Decide<COMMAND, EVENT_OUT> = engine.evolve(build)
 
-    override suspend fun <COMMAND : S2InitCommand, EVENT_OUT : Evt> evolveEnvelope(
+    override fun <COMMAND : S2InitCommand, EVENT_OUT : Evt> evolveEnvelope(
         commands: EnvelopedFlow<COMMAND>,
         build: S2EvolveInitFnc<COMMAND, ENTITY, EVENT_OUT>
     ): EnvelopedFlow<EVENT_OUT> = engine.evolveEnvelope(commands, build)
 
-    override suspend fun <COMMAND : S2Command<ID>, EVENT_OUT : Evt> evolveEnvelope(
+    override fun <COMMAND : S2Command<ID>, EVENT_OUT : Evt> evolveEnvelope(
         commands: EnvelopedFlow<COMMAND>,
         exec: S2EvolveFnc<COMMAND, ENTITY, EVENT_OUT>
     ): EnvelopedFlow<EVENT_OUT> = engine.evolveEnvelope(commands, exec)
 
-    override suspend fun <COMMAND : S2InitCommand, EVENT_OUT : Evt> evolveWithOutcomes(
+    override fun <COMMAND : S2InitCommand, EVENT_OUT : Evt> evolveWithOutcomes(
         commands: Flow<COMMAND>,
         idOf: (COMMAND) -> String,
         build: suspend (cmd: COMMAND) -> Pair<ENTITY, EVENT_OUT>
     ): Flow<PersistOutcome<EVENT_OUT>> = engine.evolveWithOutcomes(commands, idOf, build)
 
-    override suspend fun <COMMAND : S2Command<ID>, EVENT_OUT : Evt> evolveWithOutcomes(
+    override fun <COMMAND : S2Command<ID>, EVENT_OUT : Evt> evolveWithOutcomes(
         commands: Flow<COMMAND>,
         idOf: (COMMAND) -> String,
         exec: suspend (COMMAND, ENTITY) -> Pair<ENTITY, EVENT_OUT>

--- a/s2-spring/storing/s2-spring-boot-starter-storing/src/test/kotlin/s2/spring/automate/executor/S2AutomateExecutorSpringDelegationTest.kt
+++ b/s2-spring/storing/s2-spring-boot-starter-storing/src/test/kotlin/s2/spring/automate/executor/S2AutomateExecutorSpringDelegationTest.kt
@@ -1,0 +1,238 @@
+package s2.spring.automate.executor
+
+import f2.dsl.cqrs.envelope.Envelope
+import f2.dsl.cqrs.envelope.asEnvelopeWithType
+import f2.dsl.cqrs.enveloped.EnvelopedFlow
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import s2.automate.core.appevent.listener.AutomateListenerAdapter
+import s2.automate.core.appevent.publisher.AppEventPublisher
+import s2.automate.core.engine.S2AutomateEngine
+import s2.automate.core.engine.S2AutomateOutcomeEngine
+import s2.automate.core.persist.PersistOutcome
+import s2.automate.core.storing.S2AutomateStoringEvolverImpl
+import s2.automate.core.storing.S2EvolveFnc
+import s2.automate.core.storing.S2EvolveInitFnc
+import s2.dsl.automate.Evt
+import s2.dsl.automate.S2Automate
+import s2.dsl.automate.S2Command
+import s2.dsl.automate.S2InitCommand
+import s2.dsl.automate.S2State
+import s2.dsl.automate.model.WithS2Id
+import s2.dsl.automate.model.WithS2State
+import s2.sourcing.dsl.Decide
+
+/**
+ * Verifies every non-outcome method of [S2AutomateExecutorSpring] is a pure delegation
+ * to the injected engine (identity of returned value / event).
+ */
+class S2AutomateExecutorSpringDelegationTest {
+
+    enum class TestState(override var position: Int) : S2State { Created(0) }
+
+    data class TestEntity(val id: String) : WithS2Id<String>, WithS2State<TestState> {
+        override fun s2Id() = id
+        override fun s2State() = TestState.Created
+    }
+
+    data class CreateCmd(val id: String) : S2InitCommand
+    data class DoCmd(override val id: String) : S2Command<String>
+    data class TestEvt(val id: String) : Evt
+
+    // ---- sentinels ----
+
+    private val sentinelCreate = TestEvt("create-3arg")
+    private val sentinelCreateBuild = TestEvt("create-build")
+    private val sentinelTransition = TestEvt("transition")
+    private val sentinelEvolveInitFlow: Flow<TestEvt> = flowOf(TestEvt("evolve-init-flow"))
+    private val sentinelEvolveTransFlow: Flow<TestEvt> = flowOf(TestEvt("evolve-trans-flow"))
+    private val sentinelDecideInit: Decide<CreateCmd, TestEvt> = Decide { flowOf() }
+    private val sentinelDecideTrans: Decide<DoCmd, TestEvt> = Decide { flowOf() }
+    private val sentinelEnvInit: EnvelopedFlow<TestEvt> = flowOf(TestEvt("env-init").asEnvelopeWithType(type = "Evt"))
+    private val sentinelEnvTrans: EnvelopedFlow<TestEvt> = flowOf(TestEvt("env-trans").asEnvelopeWithType(type = "Evt"))
+
+    // ---- no-op engines (never driven) ----
+
+    private object NoOpLegacyEngine : S2AutomateEngine<TestState, TestEntity, String, Evt> {
+        override fun <COMMAND : S2InitCommand, ENTITY_OUT : TestEntity, EVENT_OUT : Evt> create(
+            commands: EnvelopedFlow<COMMAND>,
+            decide: suspend (cmd: Envelope<COMMAND>) -> Pair<ENTITY_OUT, Envelope<EVENT_OUT>>
+        ): EnvelopedFlow<EVENT_OUT> = error("should not be called")
+
+        override fun <COMMAND : S2Command<String>, ENTITY_OUT : TestEntity, EVENT_OUT : Evt> doTransition(
+            commands: EnvelopedFlow<COMMAND>,
+            exec: suspend (Envelope<out COMMAND>, TestEntity) -> Pair<ENTITY_OUT, Envelope<EVENT_OUT>>
+        ): EnvelopedFlow<EVENT_OUT> = error("should not be called")
+    }
+
+    private object NoOpOutcomeEngine : S2AutomateOutcomeEngine<TestState, TestEntity, String, Evt> {
+        override fun <COMMAND : S2InitCommand, ENTITY_OUT : TestEntity, EVENT_OUT : Evt> createWithOutcomes(
+            commands: EnvelopedFlow<COMMAND>,
+            decide: suspend (cmd: Envelope<COMMAND>) -> Pair<ENTITY_OUT, Envelope<EVENT_OUT>>
+        ): EnvelopedFlow<PersistOutcome<EVENT_OUT>> = error("should not be called")
+
+        override fun <COMMAND : S2Command<String>, ENTITY_OUT : TestEntity, EVENT_OUT : Evt> doTransitionWithOutcomes(
+            commands: EnvelopedFlow<COMMAND>,
+            exec: suspend (Envelope<out COMMAND>, TestEntity) -> Pair<ENTITY_OUT, Envelope<EVENT_OUT>>
+        ): EnvelopedFlow<PersistOutcome<EVENT_OUT>> = error("should not be called")
+    }
+
+    private object NoOpPublisher : AppEventPublisher {
+        override fun <EVENT> publish(event: EVENT & Any) = Unit
+    }
+
+    // ---- stub evolver returning sentinels for every delegated method ----
+
+    private inner class StubEvolver : S2AutomateStoringEvolverImpl<TestState, TestEntity, String>(
+        automateExecutor = NoOpLegacyEngine,
+        outcomeExecutor = NoOpOutcomeEngine,
+        publisher = NoOpPublisher,
+        listener = AutomateListenerAdapter<TestState, String, TestEntity, S2Automate>(),
+    ) {
+        @Suppress("UNCHECKED_CAST")
+        override suspend fun <EVENT_OUT : Evt> createWithEvent(
+            command: S2InitCommand,
+            buildEvent: suspend TestEntity.() -> EVENT_OUT,
+            buildEntity: suspend () -> TestEntity,
+        ): EVENT_OUT = sentinelCreate as EVENT_OUT
+
+        @Suppress("UNCHECKED_CAST")
+        override suspend fun <EVENT_OUT : Evt> createWithEvent(
+            command: S2InitCommand,
+            build: suspend () -> Pair<TestEntity, EVENT_OUT>,
+        ): EVENT_OUT = sentinelCreateBuild as EVENT_OUT
+
+        @Suppress("UNCHECKED_CAST")
+        override suspend fun <EVENT_OUT : Evt> doTransition(
+            command: S2Command<String>,
+            exec: suspend TestEntity.() -> Pair<TestEntity, EVENT_OUT>,
+        ): EVENT_OUT = sentinelTransition as EVENT_OUT
+
+        @Suppress("UNCHECKED_CAST")
+        override fun <COMMAND : S2InitCommand, EVENT_OUT : Evt> evolve(
+            commands: Flow<COMMAND>,
+            build: suspend (cmd: COMMAND) -> Pair<TestEntity, EVENT_OUT>
+        ): Flow<EVENT_OUT> = sentinelEvolveInitFlow as Flow<EVENT_OUT>
+
+        @Suppress("UNCHECKED_CAST")
+        override fun <COMMAND : S2Command<String>, EVENT_OUT : Evt> evolve(
+            commands: Flow<COMMAND>,
+            exec: suspend (COMMAND, TestEntity) -> Pair<TestEntity, EVENT_OUT>
+        ): Flow<EVENT_OUT> = sentinelEvolveTransFlow as Flow<EVENT_OUT>
+
+        @Suppress("UNCHECKED_CAST")
+        override fun <COMMAND : S2Command<String>, EVENT_OUT : Evt> evolve(
+            fnc: suspend (COMMAND, TestEntity) -> Pair<TestEntity, EVENT_OUT>
+        ): Decide<COMMAND, EVENT_OUT> = sentinelDecideTrans as Decide<COMMAND, EVENT_OUT>
+
+        @Suppress("UNCHECKED_CAST")
+        override fun <COMMAND : S2InitCommand, EVENT_OUT : Evt> evolve(
+            build: suspend (cmd: COMMAND) -> Pair<TestEntity, EVENT_OUT>
+        ): Decide<COMMAND, EVENT_OUT> = sentinelDecideInit as Decide<COMMAND, EVENT_OUT>
+
+        @Suppress("UNCHECKED_CAST")
+        override fun <COMMAND : S2InitCommand, EVENT_OUT : Evt> evolveEnvelope(
+            commands: EnvelopedFlow<COMMAND>,
+            build: S2EvolveInitFnc<COMMAND, TestEntity, EVENT_OUT>
+        ): EnvelopedFlow<EVENT_OUT> = sentinelEnvInit as EnvelopedFlow<EVENT_OUT>
+
+        @Suppress("UNCHECKED_CAST")
+        override fun <COMMAND : S2Command<String>, EVENT_OUT : Evt> evolveEnvelope(
+            commands: EnvelopedFlow<COMMAND>,
+            exec: S2EvolveFnc<COMMAND, TestEntity, EVENT_OUT>
+        ): EnvelopedFlow<EVENT_OUT> = sentinelEnvTrans as EnvelopedFlow<EVENT_OUT>
+    }
+
+    private fun makeExecutor(): S2AutomateExecutorSpring<TestState, String, TestEntity> {
+        val executor = object : S2AutomateExecutorSpring<TestState, String, TestEntity>() {}
+        S2AutomateExecutorSpring::class.java
+            .getDeclaredField("engine")
+            .apply { isAccessible = true }
+            .set(executor, StubEvolver())
+        return executor
+    }
+
+    // ---- tests ----
+
+    @Test
+    suspend fun `createWithEvent (buildEvent, buildEntity) delegates`() {
+        val result = makeExecutor().createWithEvent(
+            command = CreateCmd("id"),
+            buildEvent = { TestEvt(id) },
+            buildEntity = { TestEntity("id") },
+        )
+        assertThat(result).isSameAs(sentinelCreate)
+    }
+
+    @Test
+    suspend fun `createWithEvent (build) delegates`() {
+        val result = makeExecutor().createWithEvent(
+            command = CreateCmd("id"),
+            build = { TestEntity("id") to TestEvt("id") },
+        )
+        assertThat(result).isSameAs(sentinelCreateBuild)
+    }
+
+    @Test
+    suspend fun `doTransition delegates`() {
+        val result = makeExecutor().doTransition(
+            command = DoCmd("id"),
+            exec = { this to TestEvt(id) },
+        )
+        assertThat(result).isSameAs(sentinelTransition)
+    }
+
+    @Test
+    suspend fun `evolve (init flow) delegates`() {
+        val result = makeExecutor().evolve(
+            commands = flowOf(CreateCmd("id")),
+            build = { cmd: CreateCmd -> TestEntity(cmd.id) to TestEvt(cmd.id) },
+        )
+        assertThat(result).isSameAs(sentinelEvolveInitFlow)
+    }
+
+    @Test
+    suspend fun `evolve (transition flow) delegates`() {
+        val result = makeExecutor().evolve(
+            commands = flowOf(DoCmd("id")),
+            exec = { cmd: DoCmd, _: TestEntity -> TestEntity(cmd.id) to TestEvt(cmd.id) },
+        )
+        assertThat(result).isSameAs(sentinelEvolveTransFlow)
+    }
+
+    @Test
+    suspend fun `evolve (transition Decide) delegates`() {
+        val result = makeExecutor().evolve<DoCmd, TestEvt>(
+            fnc = { cmd, _ -> TestEntity(cmd.id) to TestEvt(cmd.id) },
+        )
+        assertThat(result).isSameAs(sentinelDecideTrans)
+    }
+
+    @Test
+    suspend fun `evolve (init Decide) delegates`() {
+        val result = makeExecutor().evolve<CreateCmd, TestEvt>(
+            build = { cmd -> TestEntity(cmd.id) to TestEvt(cmd.id) },
+        )
+        assertThat(result).isSameAs(sentinelDecideInit)
+    }
+
+    @Test
+    suspend fun `evolveEnvelope (init) delegates`() {
+        val result = makeExecutor().evolveEnvelope(
+            commands = flowOf(CreateCmd("id").asEnvelopeWithType(type = "Cmd")),
+            build = { cmd: CreateCmd -> TestEntity(cmd.id) to TestEvt(cmd.id) },
+        )
+        assertThat(result).isSameAs(sentinelEnvInit)
+    }
+
+    @Test
+    suspend fun `evolveEnvelope (transition) delegates`() {
+        val result = makeExecutor().evolveEnvelope(
+            commands = flowOf(DoCmd("id").asEnvelopeWithType(type = "Cmd")),
+            exec = { cmd: DoCmd, _: TestEntity -> TestEntity(cmd.id) to TestEvt(cmd.id) },
+        )
+        assertThat(result).isSameAs(sentinelEnvTrans)
+    }
+}

--- a/s2-spring/storing/s2-spring-boot-starter-storing/src/test/kotlin/s2/spring/automate/executor/S2AutomateExecutorSpringPassthroughTest.kt
+++ b/s2-spring/storing/s2-spring-boot-starter-storing/src/test/kotlin/s2/spring/automate/executor/S2AutomateExecutorSpringPassthroughTest.kt
@@ -56,12 +56,12 @@ class S2AutomateExecutorSpringPassthroughTest {
     // ---- no-op legacy engine (never called in this test) ----
 
     private object NoOpLegacyEngine : S2AutomateEngine<TestState, TestEntity, String, Evt> {
-        override suspend fun <COMMAND : S2InitCommand, ENTITY_OUT : TestEntity, EVENT_OUT : Evt> create(
+        override fun <COMMAND : S2InitCommand, ENTITY_OUT : TestEntity, EVENT_OUT : Evt> create(
             commands: EnvelopedFlow<COMMAND>,
             decide: suspend (cmd: Envelope<COMMAND>) -> Pair<ENTITY_OUT, Envelope<EVENT_OUT>>
         ): EnvelopedFlow<EVENT_OUT> = error("should not be called")
 
-        override suspend fun <COMMAND : S2Command<String>, ENTITY_OUT : TestEntity, EVENT_OUT : Evt> doTransition(
+        override fun <COMMAND : S2Command<String>, ENTITY_OUT : TestEntity, EVENT_OUT : Evt> doTransition(
             commands: EnvelopedFlow<COMMAND>,
             exec: suspend (Envelope<out COMMAND>, TestEntity) -> Pair<ENTITY_OUT, Envelope<EVENT_OUT>>
         ): EnvelopedFlow<EVENT_OUT> = error("should not be called")
@@ -70,12 +70,12 @@ class S2AutomateExecutorSpringPassthroughTest {
     // ---- no-op outcome engine (never called in this test) ----
 
     private object NoOpOutcomeEngine : S2AutomateOutcomeEngine<TestState, TestEntity, String, Evt> {
-        override suspend fun <COMMAND : S2InitCommand, ENTITY_OUT : TestEntity, EVENT_OUT : Evt> createWithOutcomes(
+        override fun <COMMAND : S2InitCommand, ENTITY_OUT : TestEntity, EVENT_OUT : Evt> createWithOutcomes(
             commands: EnvelopedFlow<COMMAND>,
             decide: suspend (cmd: Envelope<COMMAND>) -> Pair<ENTITY_OUT, Envelope<EVENT_OUT>>
         ): EnvelopedFlow<PersistOutcome<EVENT_OUT>> = error("should not be called")
 
-        override suspend fun <
+        override fun <
             COMMAND : S2Command<String>,
             ENTITY_OUT : TestEntity,
             EVENT_OUT : Evt,
@@ -101,7 +101,7 @@ class S2AutomateExecutorSpringPassthroughTest {
         publisher = NoOpPublisher,
         listener = AutomateListenerAdapter<TestState, String, TestEntity, S2Automate>(),
     ) {
-        override suspend fun <COMMAND : S2InitCommand, EVENT_OUT : Evt> evolveWithOutcomes(
+        override fun <COMMAND : S2InitCommand, EVENT_OUT : Evt> evolveWithOutcomes(
             commands: Flow<COMMAND>,
             idOf: (COMMAND) -> String,
             build: suspend (cmd: COMMAND) -> Pair<TestEntity, EVENT_OUT>
@@ -110,7 +110,7 @@ class S2AutomateExecutorSpringPassthroughTest {
             return sentinelInitFlow as Flow<PersistOutcome<EVENT_OUT>>
         }
 
-        override suspend fun <COMMAND : S2Command<String>, EVENT_OUT : Evt> evolveWithOutcomes(
+        override fun <COMMAND : S2Command<String>, EVENT_OUT : Evt> evolveWithOutcomes(
             commands: Flow<COMMAND>,
             idOf: (COMMAND) -> String,
             exec: suspend (COMMAND, TestEntity) -> Pair<TestEntity, EVENT_OUT>


### PR DESCRIPTION
Fixes SonarQube rule S6309 at the source: functions returning `Flow` must not be `suspend` — a Flow is already asynchronous, and the suspend modifier forced every implementation and stub to carry a pointless suspension point (and a `@Suppress("kotlin:S6309")` in every adapter).

## Breaking change (s2-owned abstractions only)
`suspend` removed from Flow/EnvelopedFlow-returning members of:
- `AutomatePersister`: `persistInit`, `persist`, `load(ids)`, `loadWithOutcomes`, `persistInitWithOutcomes`, `persistWithOutcomes`
- `EventRepository`: `load(id)`, `loadAll()`, `persist(events)`
- `S2AutomateEngine`: `create`, `doTransition` — `S2AutomateOutcomeEngine`: `createWithOutcomes`, `doTransitionWithOutcomes`
- `S2AutomateStoringEvolverFlow`: `evolve`, `evolveEnvelope`, `evolveWithOutcomes` — `S2AutomateSourcingDeciderFlow`: `decide(commands, ...)`

Single-value suspend functions keep `suspend` (`load(id): ENTITY?`, `persist(event): EVENT`, `createTable()`, `Loader.*`, `createWithEvent`, `doTransition(command)`, `init`/`transition`, `replayHistory`). F2Function/F2Supplier/F2Consumer (fixers-f2 published API) untouched.

## Migration notes (c2, connect, downstream)
- Overrides of the functions above: drop the `suspend` modifier (signature must match).
- Implementations that suspended before returning a Flow must become cold: wrap the body in `flow { ... }` / `emitAll(...)` (see `SpringDataAutomatePersisterFlow`). Suspension now happens at collection time, not call time.
- Call sites need no changes (calling a non-suspend function from a suspend context is fine).
- `@Suppress("kotlin:S6309")` workarounds on implementations of these contracts can be deleted.

## Verification
- `./gradlew build` + tests green locally, except pre-existing environment failures unrelated to this change: `s2-automate-documenter` and `s2-spring-boot-starter-sourcing-data*` (kotlinx-serialization resolution, green in CI) and `RedisSnapViewIntegrationTest` (requires Docker).
- `./gradlew detekt` green.