### PR TITLE
feat(automate): WithS2Iteration.withS2Iteration stamp method

### DIFF
--- a/s2-automate/s2-automate-dsl/src/commonMain/kotlin/s2/dsl/automate/model/WithS2Iteration.kt
+++ b/s2-automate/s2-automate-dsl/src/commonMain/kotlin/s2/dsl/automate/model/WithS2Iteration.kt
@@ -10,7 +10,11 @@ interface WithS2Iteration {
 	 * Returns a copy of this entity stamped with [iteration]. Called by the
 	 * storing persister at load time to carry the on-chain iteration onto the
 	 * loaded entity, so the persist phase can reuse it instead of re-querying
-	 * the chain. Implementations should return a copy (e.g. `copy(iteration = iteration)`).
+	 * the chain.
+	 *
+	 * Implementations should return a copy via a covariant return type — declare
+	 * the concrete entity type so callers keep type information and avoid casts:
+	 * `override fun withS2Iteration(iteration: Int): MyEntity = copy(iteration = iteration)`.
 	 */
 	fun withS2Iteration(iteration: Int): WithS2Iteration
 }

--- a/s2-automate/s2-automate-dsl/src/commonMain/kotlin/s2/dsl/automate/model/WithS2Iteration.kt
+++ b/s2-automate/s2-automate-dsl/src/commonMain/kotlin/s2/dsl/automate/model/WithS2Iteration.kt
@@ -5,5 +5,13 @@ import kotlin.js.JsExport
 @JsExport
 interface WithS2Iteration {
 	fun s2Iteration(): Int
+
+	/**
+	 * Returns a copy of this entity stamped with [iteration]. Called by the
+	 * storing persister at load time to carry the on-chain iteration onto the
+	 * loaded entity, so the persist phase can reuse it instead of re-querying
+	 * the chain. Implementations should return a copy (e.g. `copy(iteration = iteration)`).
+	 */
+	fun withS2Iteration(iteration: Int): WithS2Iteration
 }
 


### PR DESCRIPTION
## What
Adds `WithS2Iteration.withS2Iteration` stamp method to s2-automate-core, plus docs advising a covariant return type for it.

## Why
Needed by the SSM export drain to stamp per-item S2 iterations during batched write-back.

## Commits
- feat(automate): add WithS2Iteration.withS2Iteration stamp method
- docs(automate): advise covariant return type for withS2Iteration

## Note
Branch is behind `main` (~19 commits) — rebase before merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for attaching the loaded on-chain iteration to automation objects.
  * Automation objects can now return a stamped copy with the specified iteration value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->