### PR TITLE
fix: skip Sonar check task on Dependabot PRs

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -19,6 +19,7 @@ jobs:
       packages: write
     with:
       make-file: 'infra/make/libs.mk'
+      skip-tasks: ${{ github.actor == 'dependabot[bot]' && 'check' || '' }}
     secrets:
       FIXERS_PUBLISH_SIGNING_GPG_KEY: ${{ secrets.FIXERS_PUBLISH_SIGNING_GPG_KEY }}
       FIXERS_PUBLISH_SIGNING_GPG_KEY_PASSWORD: ${{ secrets.FIXERS_PUBLISH_SIGNING_GPG_KEY_PASSWORD }}


### PR DESCRIPTION
## Summary
Same root cause as fixers-f2#121: Dependabot-triggered PRs never get repo secrets, so \`FIXERS_SONAR_TOKEN\` is unavailable and \`infra/make/libs.mk\`'s \`check\` target (\`./gradlew sonar\`) fails with "Not authorized or project not found." Confirmed on #80 (\`sec / sonarcloud-analysis\` was already disabled via \`with-sonarcloud: false\`, but the check-step Sonar path wasn't covered).

## Changes
- \`dev.yml\`: skip the \`check\` task for Dependabot PRs via the \`skip-tasks\` input (added to \`make-jvm-workflow.yml\` in komune-io/fixers-gradle#192/#193).

## Test plan
- [ ] Confirm a Dependabot PR (#80, #84) goes green after rebasing onto main once this merges.