### PR TITLE
fix: correlate persisted events to their context by position

### DIFF
--- a/s2-automate/s2-automate-core/src/commonMain/kotlin/s2/automate/core/engine/S2AutomateEngineImpl.kt
+++ b/s2-automate/s2-automate-core/src/commonMain/kotlin/s2/automate/core/engine/S2AutomateEngineImpl.kt
@@ -8,6 +8,7 @@ import f2.dsl.fnc.operators.mapToEnvelopeWithRandomId
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.withIndex
 import s2.automate.core.appevent.publisher.AutomateEventPublisher
 import s2.automate.core.context.AutomateContext
 import s2.automate.core.context.InitTransitionAppliedContext
@@ -66,9 +67,14 @@ ENTITY : WithS2Id<ID> {
         }.chunk(automateContext.batch.size).map { transitionContexts ->
             val transitionContextsFlow = transitionContexts.asFlow()
                 as Flow<TransitionAppliedContext<STATE, ID, ENTITY, EVENT, S2Automate>>
-            persist(transitionContextsFlow).map { event ->
-                val context = transitionContexts.find { it.event == event }!!
-                sendEndDoTransitionEvent(context.entity.s2State(), context.from, context.msg, context.entity)
+            // Events are correlated to their context positionally: [AutomatePersister.persist]
+            // emits one event per received context, in the same order. Correlating by event
+            // equality would misroute two equal events of the same chunk to the same context
+            // (and NPE when a persister maps or replaces the events it emits).
+            persist(transitionContextsFlow).withIndex().map { (index, event) ->
+                transitionContexts.getOrNull(index)?.let { context ->
+                    sendEndDoTransitionEvent(context.entity.s2State(), context.from, context.msg, context.entity)
+                }
                 event as EVENT_OUT
             }
         }.flattenConcurrently(automateContext.batch.concurrency).mapToEnvelopeWithRandomId(type = "Evt")

--- a/s2-automate/s2-automate-core/src/commonMain/kotlin/s2/automate/core/persist/AutomatePersister.kt
+++ b/s2-automate/s2-automate-core/src/commonMain/kotlin/s2/automate/core/persist/AutomatePersister.kt
@@ -24,6 +24,13 @@ ENTITY : WithS2Id<ID> {
 		transitionContexts: Flow<InitTransitionAppliedContext<STATE, ID, ENTITY, EVENT, AUTOMATE>>
 	): Flow<EVENT>
 
+	/**
+	 * Persists every received context and emits the resulting events.
+	 *
+	 * Implementations MUST emit exactly one event per received context, in the same
+	 * order: the engine correlates each emitted event back to its context positionally
+	 * in order to publish the end-of-transition application events.
+	 */
 	suspend fun persist(
 		transitionContexts: Flow<TransitionAppliedContext<STATE, ID, ENTITY, EVENT, AUTOMATE>>
 	): Flow<EVENT>

--- a/s2-automate/s2-automate-core/src/jvmTest/kotlin/s2/automate/core/engine/S2AutomateEngineImplTest.kt
+++ b/s2-automate/s2-automate-core/src/jvmTest/kotlin/s2/automate/core/engine/S2AutomateEngineImplTest.kt
@@ -75,6 +75,7 @@ class S2AutomateEngineImplTest {
 
     private class StubPersister(
         private val entities: Map<String, TestEntity>,
+        private val eventMapper: (TestEvent) -> TestEvent = { it },
     ) : AutomatePersister<TestState, String, TestEntity, TestEvent, S2Automate> {
 
         override suspend fun load(
@@ -93,7 +94,7 @@ class S2AutomateEngineImplTest {
 
         override suspend fun persist(
             transitionContexts: Flow<TransitionAppliedContext<TestState, String, TestEntity, TestEvent, S2Automate>>
-        ): Flow<TestEvent> = transitionContexts.map { it.event }
+        ): Flow<TestEvent> = transitionContexts.map { eventMapper(it.event) }
     }
 
     private class RecordingPublisher : AppEventPublisher {
@@ -138,10 +139,11 @@ class S2AutomateEngineImplTest {
         guard: PassthroughGuardVerifier = PassthroughGuardVerifier(),
         publisher: RecordingPublisher = RecordingPublisher(),
         entities: Map<String, TestEntity> = mapOf("1" to TestEntity("1", TestState.Created)),
+        eventMapper: (TestEvent) -> TestEvent = { it },
     ): S2AutomateEngineImpl<TestState, String, TestEntity, TestEvent> {
         val automateContext = AutomateContext(automate, S2BatchProperties(size = 10))
         val automatePublisher = AutomateEventPublisher<TestState, String, TestEntity, S2Automate>(publisher)
-        return S2AutomateEngineImpl(automateContext, guard, StubPersister(entities), automatePublisher)
+        return S2AutomateEngineImpl(automateContext, guard, StubPersister(entities, eventMapper), automatePublisher)
     }
 
     @Test
@@ -206,5 +208,48 @@ class S2AutomateEngineImplTest {
             }.toList()
         }
         assertTrue(exception.errors.single().type == "ERROR_ENTITY_NOT_FOUND")
+    }
+
+    @Test
+    suspend fun `doTransition correlates equal events to their own context`() {
+        val publisher = RecordingPublisher()
+        val engine = engine(
+            publisher = publisher,
+            entities = mapOf(
+                "1" to TestEntity("1", TestState.Created),
+                "2" to TestEntity("2", TestState.Created),
+            ),
+        )
+
+        val commands = flowOf(DoCmd("1"), DoCmd("2")).mapToEnvelopeWithRandomId(type = "Cmd")
+        // Both transitions produce the very same event value: correlating by event equality
+        // would route both of them to the context of command "1".
+        val events = engine.doTransition(commands) { _, entity ->
+            TestEntity(entity.id, TestState.Active) to DoneEvt("shared").asEnvelopeWithType("Evt")
+        }.toList()
+
+        assertEquals(listOf("shared", "shared"), events.map { it.data.entityId })
+        val ended = publisher.published.filterIsInstance<AutomateTransitionEnded<*, *>>()
+        assertEquals(listOf("1", "2"), ended.map { (it.entity as TestEntity).id })
+        assertEquals(listOf("1", "2"), ended.map { (it.msg as DoCmd).id })
+    }
+
+    @Test
+    suspend fun `doTransition still publishes lifecycle events when the persister replaces the events`() {
+        val publisher = RecordingPublisher()
+        val engine = engine(
+            publisher = publisher,
+            entities = mapOf("1" to TestEntity("1", TestState.Created)),
+            eventMapper = { DoneEvt("persisted") },
+        )
+
+        val commands = flowOf(DoCmd("1")).mapToEnvelopeWithRandomId(type = "Cmd")
+        val events = engine.doTransition(commands) { cmd, entity ->
+            TestEntity(entity.id, TestState.Active) to DoneEvt(cmd.data.id).asEnvelopeWithType("Evt")
+        }.toList()
+
+        assertEquals(listOf("persisted"), events.map { it.data.entityId })
+        val ended = publisher.published.filterIsInstance<AutomateTransitionEnded<*, *>>().single()
+        assertEquals("1", (ended.entity as TestEntity).id)
     }
 }


### PR DESCRIPTION
Closes #105

## Problem

`S2AutomateEngineImpl.doTransition` correlated each persisted event back to its transition context with `transitionContexts.find { it.event == event }!!`:

- two **equal** data-class events in the same chunk both resolved to the *first* matching context, so `AutomateTransitionEnded` / `AutomateStateExited` / `AutomateSessionStopped` were published with the wrong entity, state and command (and one context never got its events at all);
- the `!!` threw an NPE whenever a persister mapped, enriched or replaced the events it emits.

## What changed

- `S2AutomateEngineImpl.doTransition` now pairs events with contexts positionally (`persist(...).withIndex()`), which is the correlation the persister contract already implies. An event with no matching context no longer crashes the flow.
- `AutomatePersister.persist` KDoc now states the contract explicitly: one event per received context, same order.

## How verified

`./gradlew :s2-automate:s2-automate-core:jvmTest` — green.

Two new tests in `S2AutomateEngineImplTest`, both confirmed **failing on the pre-fix code** and passing after:

- `doTransition correlates equal events to their own context` — two commands whose transitions produce the identical event value; asserts the two `AutomateTransitionEnded` events carry entities `1` and `2` (pre-fix: `1` twice).
- `doTransition still publishes lifecycle events when the persister replaces the events` — persister emits a different event instance (pre-fix: NPE).

## Behavior change

Internal only, no API change. Persister implementations that already emit one event per context in order are unaffected; the previously undocumented ordering requirement is now written down.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved lifecycle event correlation when concurrent transitions emit identical events.
  * Preserved correct lifecycle updates when persistence transforms emitted events.
  * Prevented failures caused by duplicate or modified events.

* **Documentation**
  * Clarified persistence requirements for event ordering and one-to-one event emission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->