### PR TITLE
fix: add an opt-in guard validating init transitions

### DIFF
--- a/s2-automate/s2-automate-core/src/commonMain/kotlin/s2/automate/core/error/AutomateError.kt
+++ b/s2-automate/s2-automate-core/src/commonMain/kotlin/s2/automate/core/error/AutomateError.kt
@@ -14,6 +14,11 @@ fun invalidTransitionError(state: String, command: String) =
 		"Not available transition from $state with command $command",
 		mapOf("from" to state, "command" to command))
 
+fun invalidInitTransitionError(command: String) =
+	s2error("ERROR_INVALID_INIT_TRANSITION",
+		"Not available init transition with command $command",
+		mapOf("command" to command))
+
 fun entityNotFoundError(id: String) =
 	s2error("ERROR_ENTITY_NOT_FOUND", "Entity with id[$id] not found", mapOf("id" to id))
 

--- a/s2-automate/s2-automate-core/src/commonMain/kotlin/s2/automate/core/guard/InitTransitionStateGuard.kt
+++ b/s2-automate/s2-automate-core/src/commonMain/kotlin/s2/automate/core/guard/InitTransitionStateGuard.kt
@@ -1,0 +1,37 @@
+package s2.automate.core.guard
+
+import s2.automate.core.context.InitTransitionContext
+import s2.automate.core.error.invalidInitTransitionError
+import s2.dsl.automate.Automate
+import s2.dsl.automate.S2State
+import s2.dsl.automate.model.WithS2Id
+import s2.dsl.automate.model.WithS2State
+
+/**
+ * Rejects init commands that are not declared as an init transition of the automate.
+ *
+ * This is the init counterpart of [TransitionStateGuard]. It is not part of the default
+ * guards of `S2SpringAdapterBase`: automates that declare their creation transition
+ * without `init<...>` (for instance `transaction<CreateCmd> { to = ... }` with no `from`)
+ * do not expose any init transition, and would see every creation rejected. Enable it by
+ * overriding `S2SpringAdapterBase.validateInitTransitions()` or by adding it to `guards()`.
+ */
+class InitTransitionStateGuard<STATE, ID, ENTITY, EVENT, AUTOMATE>
+	: GuardAdapter<STATE, ID, ENTITY, EVENT, AUTOMATE>() where
+STATE : S2State,
+ENTITY : WithS2State<STATE>,
+ENTITY : WithS2Id<ID>,
+AUTOMATE : Automate {
+
+	override suspend fun evaluateInit(context: InitTransitionContext<AUTOMATE>): GuardResult {
+		val command = context.msg
+		val isCmdValid = context.automateContext.automate.isAvailableInitTransition(command)
+		return if (isCmdValid) {
+			GuardResult.valid()
+		} else {
+			GuardResult.error(
+				invalidInitTransitionError("$command")
+			)
+		}
+	}
+}

--- a/s2-automate/s2-automate-core/src/jvmTest/kotlin/s2/automate/core/guard/GuardTest.kt
+++ b/s2-automate/s2-automate-core/src/jvmTest/kotlin/s2/automate/core/guard/GuardTest.kt
@@ -41,6 +41,7 @@ class GuardTest {
     }
 
     data class CreateCmd(val id: String) : S2InitCommand
+    data class UndeclaredCreateCmd(val id: String) : S2InitCommand
     data class DoCmd(override val id: String) : S2Command<String>
     data class OtherCmd(override val id: String) : S2Command<String>
 
@@ -134,6 +135,50 @@ class GuardTest {
         assertEquals("ERROR_INVALID_TRANSITION", result.errors.single().type)
     }
 
+    // ---- InitTransitionStateGuard ----
+
+    @Test
+    suspend fun `InitTransitionStateGuard accepts a declared init command`() {
+        val guard = InitTransitionStateGuard<TestState, String, TestEntity, String, S2Automate>()
+        val result = guard.evaluateInit(InitTransitionContext(automateContext, CreateCmd("1")))
+        assertTrue(result.isValid())
+    }
+
+    @Test
+    suspend fun `InitTransitionStateGuard rejects an init command not declared by the automate`() {
+        val guard = InitTransitionStateGuard<TestState, String, TestEntity, String, S2Automate>()
+        val result = guard.evaluateInit(InitTransitionContext(automateContext, UndeclaredCreateCmd("1")))
+        assertFalse(result.isValid())
+        assertEquals("ERROR_INVALID_INIT_TRANSITION", result.errors.single().type)
+    }
+
+    @Test
+    suspend fun `InitTransitionStateGuard rejects a transition command used as an init command`() {
+        val guard = InitTransitionStateGuard<TestState, String, TestEntity, String, S2Automate>()
+        val result = guard.evaluateInit(InitTransitionContext(automateContext, DoCmd("1")))
+        assertFalse(result.isValid())
+    }
+
+    @Test
+    suspend fun `InitTransitionStateGuard rejects a creation declared without an init transition`() {
+        // Automates declaring their creation with `transaction<CMD> { to = ... }` and no `from`
+        // register no transition at all, hence expose no init transition: enabling the guard on
+        // such an automate rejects every creation. This is why the guard is opt-in.
+        val looseAutomate = s2 {
+            name = "GuardTestLoose"
+            transaction<CreateCmd> {
+                to = TestState.Created
+                role = TestRole
+            }
+        }
+        val guard = InitTransitionStateGuard<TestState, String, TestEntity, String, S2Automate>()
+        val context = InitTransitionContext(
+            AutomateContext(looseAutomate, S2BatchProperties()),
+            CreateCmd("1"),
+        )
+        assertFalse(guard.evaluateInit(context).isValid())
+    }
+
     // ---- GuardVerifierImpl ----
 
     private fun verifier(
@@ -148,6 +193,17 @@ class GuardTest {
         val publisher = RecordingPublisher()
         verifier(publisher).evaluateInit(InitTransitionContext(automateContext, CreateCmd("1")))
         assertTrue(publisher.published.isEmpty())
+    }
+
+    @Test
+    suspend fun `evaluateInit publishes not-accepted and throws for an undeclared init command`() {
+        val publisher = RecordingPublisher()
+        val exception = assertThrows<AutomateException> {
+            verifier(publisher, listOf(InitTransitionStateGuard()))
+                .evaluateInit(InitTransitionContext(automateContext, UndeclaredCreateCmd("1")))
+        }
+        assertEquals("ERROR_INVALID_INIT_TRANSITION", exception.errors.single().type)
+        assertEquals(1, publisher.published.filterIsInstance<AutomateTransitionNotAccepted>().size)
     }
 
     @Test

--- a/s2-spring/s2-spring-core/build.gradle.kts
+++ b/s2-spring/s2-spring-core/build.gradle.kts
@@ -8,4 +8,6 @@ dependencies {
 	api(project(":s2-automate:s2-automate-core"))
 	implementation(libs.spring.boot.autoconfigure)
 	kapt(libs.spring.boot.configuration.processor)
+
+	testImplementation(libs.bundles.test.junit)
 }

--- a/s2-spring/s2-spring-core/src/main/kotlin/s2/spring/core/S2SpringAdapterBase.kt
+++ b/s2-spring/s2-spring-core/src/main/kotlin/s2/spring/core/S2SpringAdapterBase.kt
@@ -7,6 +7,7 @@ import s2.automate.core.context.AutomateContext
 import s2.automate.core.guard.Guard
 import s2.automate.core.guard.GuardVerifier
 import s2.automate.core.guard.GuardVerifierImpl
+import s2.automate.core.guard.InitTransitionStateGuard
 import s2.automate.core.guard.TransitionStateGuard
 import s2.dsl.automate.Evt
 import s2.dsl.automate.S2Automate
@@ -37,8 +38,23 @@ EVENT: Evt{
 		return AutomateEventPublisher(eventPublisher)
 	}
 
-	protected open fun guards(): List<Guard<STATE, ID, ENTITY, EVENT, S2Automate>> = listOf(
-		TransitionStateGuard()
+	/**
+	 * Whether init commands are checked against the init transitions declared by the automate.
+	 *
+	 * Disabled by default: until now init transitions were never validated, and an automate
+	 * may declare its creation transition in a way that exposes no init transition at all
+	 * (`transaction<CreateCmd> { to = ... }` without `from`). Enabling the check on such an
+	 * automate rejects every creation, so it is opt-in.
+	 *
+	 * Override and return `true` to have [InitTransitionStateGuard] reject any init command
+	 * that is not declared with `init<...>` in the automate.
+	 */
+	protected open fun validateInitTransitions(): Boolean = false
+
+	protected open fun guards(): List<Guard<STATE, ID, ENTITY, EVENT, S2Automate>> = listOfNotNull(
+		TransitionStateGuard(),
+		InitTransitionStateGuard<STATE, ID, ENTITY, EVENT, S2Automate>()
+			.takeIf { validateInitTransitions() }
 	)
 
 	@Autowired

--- a/s2-spring/s2-spring-core/src/test/kotlin/s2/spring/core/S2SpringAdapterBaseTest.kt
+++ b/s2-spring/s2-spring-core/src/test/kotlin/s2/spring/core/S2SpringAdapterBaseTest.kt
@@ -1,0 +1,64 @@
+package s2.spring.core
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import s2.automate.core.guard.Guard
+import s2.automate.core.guard.InitTransitionStateGuard
+import s2.automate.core.guard.TransitionStateGuard
+import s2.dsl.automate.Evt
+import s2.dsl.automate.S2Automate
+import s2.dsl.automate.S2InitCommand
+import s2.dsl.automate.S2Role
+import s2.dsl.automate.S2State
+import s2.dsl.automate.builder.s2
+import s2.dsl.automate.model.WithS2Id
+import s2.dsl.automate.model.WithS2State
+
+class S2SpringAdapterBaseTest {
+
+	enum class TestState(override val position: Int) : S2State {
+		Created(0)
+	}
+
+	object TestRole : S2Role
+
+	data class TestEntity(val id: String) : WithS2Id<String>, WithS2State<TestState> {
+		override fun s2Id(): String = id
+		override fun s2State(): TestState = TestState.Created
+	}
+
+	data class CreateCmd(val id: String) : S2InitCommand
+
+	class TestEvent : Evt
+
+	private open class TestAdapter(
+		private val validateInit: Boolean,
+	) : S2SpringAdapterBase<TestEntity, TestState, TestEvent, String>() {
+		override fun automate(): S2Automate = s2 {
+			name = "AdapterTest"
+			init<CreateCmd> {
+				to = TestState.Created
+				role = TestRole
+			}
+		}
+
+		override fun validateInitTransitions(): Boolean = validateInit
+
+		fun exposedGuards(): List<Guard<TestState, String, TestEntity, TestEvent, S2Automate>> = guards()
+	}
+
+	@Test
+	fun `init transitions are not validated by default`() {
+		val guards = TestAdapter(validateInit = false).exposedGuards()
+		assertThat(guards).hasSize(1)
+		assertThat(guards.single()).isInstanceOf(TransitionStateGuard::class.java)
+	}
+
+	@Test
+	fun `init transitions are validated when the check is opted in`() {
+		val guards = TestAdapter(validateInit = true).exposedGuards()
+		assertThat(guards).hasSize(2)
+		assertThat(guards[0]).isInstanceOf(TransitionStateGuard::class.java)
+		assertThat(guards[1]).isInstanceOf(InitTransitionStateGuard::class.java)
+	}
+}


### PR DESCRIPTION
Closes #101

## Problem

Init transitions were never validated: `S2Automate.isAvailableInitTransition` had zero production call sites and `GuardAdapter.evaluateInit` returned `valid()` unconditionally. Any `S2InitCommand` — including one the automate never declares — created an aggregate.

## What changed

- **New `InitTransitionStateGuard`** (`s2-automate-core`), the init counterpart of `TransitionStateGuard`: calls `automate.isAvailableInitTransition(command)` and rejects with the new `invalidInitTransitionError` / `ERROR_INVALID_INIT_TRANSITION` otherwise.
- **New `S2SpringAdapterBase.validateInitTransitions()` hook** (defaults to `false`). `guards()` adds `InitTransitionStateGuard` only when it is overridden to `true`.

## ⚠️ Why the guard is opt-in rather than on by default

The issue proposes adding it to the default `guards()`. **That breaks this repo's own orderbook sample**, and would break any consumer that declares creation the same way:

```kotlin
// sample/orderbook-sourcing/.../S2OrderBook.kt
transaction<OrderBookCreateCommand> {   // no `from`
    to = OrderBookState.Created
    ...
}
```

`S2AutomateBuilder.transaction` builds one `S2Transition` per `from`, and with `from == null` and `froms` empty it registers **no transition at all**. So `isAvailableInitTransition(OrderBookCreateCommand)` is `false`, and a default-on guard would reject every `OrderBookCreateCommand` — the sourcing path (`S2AutomateSourcingDeciderImpl.decide` → `S2AutomateEngine.create` → `guardExecutor.evaluateInit`) goes straight through this guard. The orderbook app tests that would have caught this need Docker (testcontainers), so the breakage is proven by a unit test instead (see below) rather than by running them.

Turning validation on is therefore a deliberate, per-adapter decision:

```kotlin
override fun validateInitTransitions(): Boolean = true
```

Happy to flip the default to `true` in a follow-up (major) release together with a fix of the sample's automate declaration — say the word and I will.

## How verified

- `./gradlew :s2-automate:s2-automate-core:jvmTest` — green (16 tests in `GuardTest`, 5 new).
- `./gradlew :s2-spring:s2-spring-core:test` — green (new test source set for this module, 2 tests).
- `./gradlew :s2-spring:storing:s2-spring-boot-starter-storing:compileKotlin :s2-spring:sourcing:s2-spring-boot-starter-sourcing:compileKotlin` — the `S2SpringAdapterBase` subclasses still compile.
- `detekt` on both touched modules — clean.

New tests:

- `InitTransitionStateGuard accepts a declared init command`
- `InitTransitionStateGuard rejects an init command not declared by the automate` → `ERROR_INVALID_INIT_TRANSITION`
- `InitTransitionStateGuard rejects a transition command used as an init command`
- `InitTransitionStateGuard rejects a creation declared without an init transition` — pins the orderbook-style declaration described above, i.e. the reason the guard is opt-in
- `evaluateInit publishes not-accepted and throws for an undeclared init command` — end-to-end through `GuardVerifierImpl`
- `S2SpringAdapterBaseTest`: default `guards()` has no init guard; opting in adds it

## Behavior change

None by default — `guards()` keeps returning only `TransitionStateGuard` unless an adapter opts in. Consumers who opt in will see previously-accepted undeclared init commands fail with `ERROR_INVALID_INIT_TRANSITION`.