### PR TITLE
fix: declare direct kotlinx-serialization dependencies

### DIFF
--- a/s2-automate/s2-automate-dsl/build.gradle.kts
+++ b/s2-automate/s2-automate-dsl/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
 
 dependencies {
 	commonMainApi(libs.f2.dsl.cqrs)
+	commonMainApi(libs.kotlinx.serialization.core)
 
 	"jvmTestImplementation"(libs.bundles.test.junit)
 }

--- a/s2-spring/sourcing/s2-spring-boot-starter-sourcing-data-mongodb/build.gradle.kts
+++ b/s2-spring/sourcing/s2-spring-boot-starter-sourcing-data-mongodb/build.gradle.kts
@@ -6,4 +6,5 @@ plugins {
 dependencies {
 	api(project(":s2-spring:sourcing:s2-spring-boot-starter-sourcing-data"))
 	api(libs.spring.boot.starter.data.mongodb.reactive)
+	implementation(libs.kotlinx.serialization.json)
 }

--- a/sample/orderbook-sourcing/orderbook-sourcing-domain/build.gradle.kts
+++ b/sample/orderbook-sourcing/orderbook-sourcing-domain/build.gradle.kts
@@ -12,6 +12,7 @@ tasks.matching { it.name == "compileProductionLibraryKotlinJs" }.configureEach {
 dependencies {
 	commonMainApi(project(":s2-automate:s2-automate-dsl"))
 	commonMainApi(libs.f2.dsl.function)
+	commonMainApi(libs.kotlinx.serialization.core)
 	commonMainApi(libs.arrow.core)
 	commonMainApi(libs.arrow.optics)
 	kspJvm(libs.arrow.optics.ksp)


### PR DESCRIPTION
Closes #109

## Problem

Three modules compiled against kotlinx-serialization while declaring no dependency on it, relying on it leaking transitively through an f2 `api` dependency:

| module | usage |
| --- | --- |
| `s2-automate/s2-automate-dsl` | `@Serializable` on `S2Automate`, `S2Transition` |
| `s2-spring/sourcing/s2-spring-boot-starter-sourcing-data-mongodb` | `Json`, `serializer()`, `InternalSerializationApi` |
| `sample/orderbook-sourcing/orderbook-sourcing-domain` | `@Serializable`, `@SerialName` |

Any upstream dependency cleanup breaks these builds.

## What changed

- `s2-automate-dsl`: `commonMainApi(libs.kotlinx.serialization.core)` — `api`, since `@Serializable` is on published public types.
- `s2-spring-boot-starter-sourcing-data-mongodb`: `implementation(libs.kotlinx.serialization.json)` — same declaration as its r2dbc sibling starter.
- `orderbook-sourcing-domain`: `commonMainApi(libs.kotlinx.serialization.core)`.

Versions keep coming from the BOM (no version in the catalog entries), so nothing is pinned here.

## How verified

- `./gradlew :s2-automate:s2-automate-dsl:build :s2-spring:sourcing:s2-spring-boot-starter-sourcing-data-mongodb:build :sample:orderbook-sourcing:orderbook-sourcing-domain:build` (tests + detekt included) — green.
- `dependencyInsight` confirms the declared coordinates resolve through `kotlinx-serialization-bom` to `1.11.0` — the same version as before, so no resolution change:
  - `s2-automate-dsl` / `jvmCompileClasspath` → `org.jetbrains.kotlinx:kotlinx-serialization-core:1.11.0`
  - mongodb starter / `compileClasspath` → `org.jetbrains.kotlinx:kotlinx-serialization-json:1.11.0`

## Behavior change

None. Build metadata only; the same artifacts at the same versions were already on the classpath transitively.