### PR TITLE
fix: batch storing persist instead of buffering the whole flow

### DIFF
--- a/s2-spring/storing/s2-spring-boot-starter-storing-data/src/main/kotlin/s2/spring/automate/data/persister/SpringDataAutomateCoroutinePersisterFlow.kt
+++ b/s2-spring/storing/s2-spring-boot-starter-storing-data/src/main/kotlin/s2/spring/automate/data/persister/SpringDataAutomateCoroutinePersisterFlow.kt
@@ -4,7 +4,6 @@ import f2.dsl.fnc.operators.batch
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.firstOrNull
-import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import org.springframework.data.repository.kotlin.CoroutineCrudRepository
 import s2.automate.core.config.S2BatchProperties
@@ -51,19 +50,12 @@ ENTITY : WithS2Id<ID> {
 
 	override suspend fun persist(
 		transitionContexts: Flow<TransitionAppliedContext<STATE, ID, ENTITY, EVENT, S2Automate>>
-	): Flow<EVENT> = flow {
-		val entities = mutableListOf<ENTITY>()
-		val events = mutableListOf<EVENT>()
-
-		transitionContexts.collect { context ->
-			entities.add(context.entity)
-			events.add(context.event)
-		}
-
-		repository.saveAll(entities).collect()
-
-		events.forEach { event ->
-			emit(event)
+	): Flow<EVENT> {
+		return transitionContexts.batch(batchParams.asBatch()) { context ->
+			val entities = context.map { it.entity }
+			val events = context.map { it.event }
+			repository.saveAll(entities).collect()
+			events
 		}
 	}
 

--- a/s2-spring/storing/s2-spring-boot-starter-storing-data/src/test/kotlin/s2/spring/automate/data/persister/SpringDataPersisterFlowTest.kt
+++ b/s2-spring/storing/s2-spring-boot-starter-storing-data/src/test/kotlin/s2/spring/automate/data/persister/SpringDataPersisterFlowTest.kt
@@ -70,12 +70,17 @@ class SpringDataPersisterFlowTest {
         initial: Map<String, TestEntity> = emptyMap(),
     ) : CoroutineCrudRepository<TestEntity, String> {
         val store = initial.toMutableMap()
+
+        /** One entry per `saveAll(Iterable)` call, holding the ids saved by that call. */
+        val saveAllBatches = mutableListOf<List<String>>()
+
         override suspend fun <S : TestEntity> save(entity: S): TestEntity {
             store[entity.s2Id()] = entity
             return entity
         }
 
         override fun <S : TestEntity> saveAll(entities: Iterable<S>): Flow<S> {
+            saveAllBatches.add(entities.map { it.s2Id() })
             entities.forEach { store[it.s2Id()] = it }
             return entities.toList().asFlow()
         }
@@ -119,6 +124,34 @@ class SpringDataPersisterFlowTest {
         val events = persister.persist(flowOf(transitionContext("1"), transitionContext("2"))).toList()
         assertThat(events.map { it.id }).containsExactly("1", "2")
         assertThat(repository.store.keys).containsExactlyInAnyOrder("1", "2")
+    }
+
+    @Test
+    suspend fun `coroutine persister persists in chunks instead of buffering the whole flow`() {
+        val repository = InMemoryCoroutineRepository()
+        val persister = SpringDataAutomateCoroutinePersisterFlow<TestState, String, TestEntity, TestEvent>(
+            repository, S2BatchProperties(size = 2, concurrency = 1),
+        )
+        val contexts = (1..5).map { transitionContext("$it") }
+        val events = persister.persist(contexts.asFlow()).toList()
+
+        // one saveAll per chunk of `size`, not a single saveAll holding the whole flow
+        assertThat(repository.saveAllBatches)
+            .containsExactly(listOf("1", "2"), listOf("3", "4"), listOf("5"))
+        assertThat(events.map { it.id }).containsExactly("1", "2", "3", "4", "5")
+    }
+
+    @Test
+    suspend fun `coroutine persister persistInit persists in chunks`() {
+        val repository = InMemoryCoroutineRepository()
+        val persister = SpringDataAutomateCoroutinePersisterFlow<TestState, String, TestEntity, TestEvent>(
+            repository, S2BatchProperties(size = 2, concurrency = 1),
+        )
+        val events = persister.persistInit((1..5).map { initContext("$it") }.asFlow()).toList()
+
+        assertThat(repository.saveAllBatches)
+            .containsExactly(listOf("1", "2"), listOf("3", "4"), listOf("5"))
+        assertThat(events.map { it.id }).containsExactly("1", "2", "3", "4", "5")
     }
 
     @Test


### PR DESCRIPTION
Closes #107

## Problem

`SpringDataAutomateCoroutinePersisterFlow.persist` collected the **entire** flow of `TransitionAppliedContext` into two in-memory lists, then issued a single `repository.saveAll(...)` and replayed the buffered events. Memory grew linearly with the flow, and the write was all-or-nothing: a failure at the end lost the whole batch.

`persistInit` in the same class (and both `persist`/`persistInit` in `SpringDataAutomateReactivePersisterFlow`) already used the `batch` operator correctly — the coroutine `persist` was the odd one out.

## Change

`persist` now uses the same `transitionContexts.batch(batchParams.asBatch()) { ... }` shape as `persistInit`. Entities are saved chunk by chunk, respecting the configured `S2BatchProperties` (`size` / `concurrency`), and events are emitted as each chunk completes rather than after the whole flow drains.

Net effect: one `saveAll` per chunk instead of one `saveAll` for everything.

## Verification

Added two tests to `SpringDataPersisterFlowTest`, backed by a `saveAllBatches` recorder on the in-memory coroutine repository:

- `coroutine persister persists in chunks instead of buffering the whole flow` — 5 contexts with `S2BatchProperties(size = 2, concurrency = 1)` must produce `[[1,2], [3,4], [5]]` saveAll calls, with events emitted in order `1..5`.
- `coroutine persister persistInit persists in chunks` — same assertion for the already-correct `persistInit`, so the shared shape stays pinned.

**Confirmed red before the fix**: with the `persist` change stashed and only the tests applied, the new `persist` test fails (a single `saveAll` holding all 5 ids). With the fix applied, all 10 tests in the class pass.

```
./gradlew :s2-spring:storing:s2-spring-boot-starter-storing-data:test --tests '*SpringDataPersisterFlowTest*'
BUILD SUCCESSFUL
```

## Consumer-visible behaviour

- **Chunked writes.** `persist` previously wrote every entity in one transaction-less `saveAll`; it now writes one `saveAll` per chunk. A mid-flow failure can therefore leave earlier chunks persisted, whereas before nothing was written. This matches what `persistInit` and the reactive persister have always done, so it aligns the coroutine path with the rest of the framework rather than introducing a new semantic.
- **Streaming emission.** Events are emitted progressively instead of only after the full flow is consumed — better latency and bounded memory. Ordering is preserved at `concurrency = 1`; with `concurrency > 1` chunks may complete out of order, which is the pre-existing behaviour of `batch` used by `persistInit`.

## Merge order

Independent of open PRs #112 / #113 / #114 / #115 — touches only `s2-spring-boot-starter-storing-data`. No conflicts expected.