### PR TITLE
refactor: deprecate dead Evolve type and the storing evolve() names

### DIFF
--- a/s2-automate/s2-automate-core/src/commonMain/kotlin/s2/automate/core/storing/S2AutomateStoringEvolverFlow.kt
+++ b/s2-automate/s2-automate-core/src/commonMain/kotlin/s2/automate/core/storing/S2AutomateStoringEvolverFlow.kt
@@ -13,46 +13,165 @@ import s2.sourcing.dsl.Decide
 typealias S2EvolveInitFnc<COMMAND, ENTITY, EVENT_OUT> = suspend (cmd: COMMAND) -> Pair<ENTITY, EVENT_OUT>
 typealias S2EvolveFnc<COMMAND, ENTITY, EVENT_OUT> = suspend (COMMAND, ENTITY) -> Pair<ENTITY, EVENT_OUT>
 
+/**
+ * Flow-oriented storing API.
+ *
+ * ### Naming
+ *
+ * Historically every method here was called `evolve`, which collides with the event-sourcing
+ * `evolve` (the `event -> state` fold of [s2.sourcing.dsl.view.View]) while doing something
+ * entirely different: these methods take *commands*, run them through the automate and emit
+ * *events*. That is a decide step, not a fold.
+ *
+ * Each `evolve*` method therefore has a clearer alias named after what it actually does —
+ * [create]/[transition] and their `Envelope`/`WithOutcomes` variants — mirroring the vocabulary
+ * already used by `S2AutomateEngine`. The aliases are `open` defaults delegating to the
+ * `evolve*` methods, so existing implementations keep working untouched; the `evolve*` methods
+ * are deprecated and will be removed in a future major release.
+ */
+@Suppress("DEPRECATION", "TooManyFunctions")
 interface S2AutomateStoringEvolverFlow<STATE : S2State, ID, ENTITY : WithS2State<STATE>, EVENT: Evt> {
 
+	@Deprecated(
+		message = "Confusing name: this decides events from init commands, it is not a sourcing fold.",
+		replaceWith = ReplaceWith("create(commands, build)"),
+	)
 	suspend fun <COMMAND: S2InitCommand, EVENT_OUT: EVENT> evolve(
 		commands: Flow<COMMAND>,
 		build: S2EvolveInitFnc<COMMAND, ENTITY, EVENT_OUT>
 	): Flow<EVENT_OUT>
 
+	@Deprecated(
+		message = "Confusing name: this decides events from init commands, it is not a sourcing fold.",
+		replaceWith = ReplaceWith("createEnvelope(commands, build)"),
+	)
 	suspend fun <COMMAND: S2InitCommand, EVENT_OUT: EVENT> evolveEnvelope(
 		commands: EnvelopedFlow<COMMAND>,
 		build: S2EvolveInitFnc<COMMAND, ENTITY, EVENT_OUT>
 	): EnvelopedFlow<EVENT_OUT>
 
+	@Deprecated(
+		message = "Confusing name: this builds a Decide from an init command handler, it is not a sourcing fold.",
+		replaceWith = ReplaceWith("decideCreate(build)"),
+	)
 	fun <COMMAND: S2InitCommand, EVENT_OUT: EVENT> evolve(
 		build: S2EvolveInitFnc<COMMAND, ENTITY, EVENT_OUT>
 	): Decide<COMMAND, EVENT_OUT>
 
+	@Deprecated(
+		message = "Confusing name: this decides events from transition commands, it is not a sourcing fold.",
+		replaceWith = ReplaceWith("transition(commands, exec)"),
+	)
 	suspend fun <COMMAND: S2Command<ID>, EVENT_OUT: EVENT> evolve(
 		commands: Flow<COMMAND>,
 		exec: S2EvolveFnc<COMMAND, ENTITY, EVENT_OUT>
 	): Flow<EVENT_OUT>
 
+	@Deprecated(
+		message = "Confusing name: this decides events from transition commands, it is not a sourcing fold.",
+		replaceWith = ReplaceWith("transitionEnvelope(commands, exec)"),
+	)
 	suspend fun <COMMAND: S2Command<ID>, EVENT_OUT: EVENT> evolveEnvelope(
 		commands: EnvelopedFlow<COMMAND>,
 		exec: S2EvolveFnc<COMMAND, ENTITY, EVENT_OUT>
 	): EnvelopedFlow<EVENT_OUT>
 
+	@Deprecated(
+		message = "Confusing name: this builds a Decide from a transition handler, it is not a sourcing fold.",
+		replaceWith = ReplaceWith("decideTransition(fnc)"),
+	)
 	fun <COMMAND : S2Command<ID>, EVENT_OUT : EVENT> evolve(
 		fnc: S2EvolveFnc<COMMAND, ENTITY, EVENT_OUT>
 	): Decide<COMMAND, EVENT_OUT>
 
+	@Deprecated(
+		message = "Confusing name: this decides events from init commands, it is not a sourcing fold.",
+		replaceWith = ReplaceWith("createWithOutcomes(commands, idOf, build)"),
+	)
 	suspend fun <COMMAND: S2InitCommand, EVENT_OUT: EVENT> evolveWithOutcomes(
 		commands: Flow<COMMAND>,
 		idOf: (COMMAND) -> String,
 		build: S2EvolveInitFnc<COMMAND, ENTITY, EVENT_OUT>
 	): Flow<PersistOutcome<EVENT_OUT>>
 
+	@Deprecated(
+		message = "Confusing name: this decides events from transition commands, it is not a sourcing fold.",
+		replaceWith = ReplaceWith("transitionWithOutcomes(commands, idOf, exec)"),
+	)
 	suspend fun <COMMAND: S2Command<ID>, EVENT_OUT: EVENT> evolveWithOutcomes(
 		commands: Flow<COMMAND>,
 		idOf: (COMMAND) -> String,
 		exec: S2EvolveFnc<COMMAND, ENTITY, EVENT_OUT>
 	): Flow<PersistOutcome<EVENT_OUT>>
+
+	/**
+	 * Creates one entity per init command and emits the resulting events.
+	 * Preferred name for [evolve].
+	 */
+	suspend fun <COMMAND: S2InitCommand, EVENT_OUT: EVENT> create(
+		commands: Flow<COMMAND>,
+		build: S2EvolveInitFnc<COMMAND, ENTITY, EVENT_OUT>
+	): Flow<EVENT_OUT> = evolve(commands, build)
+
+	/**
+	 * Envelope-preserving variant of [create]. Preferred name for [evolveEnvelope].
+	 */
+	suspend fun <COMMAND: S2InitCommand, EVENT_OUT: EVENT> createEnvelope(
+		commands: EnvelopedFlow<COMMAND>,
+		build: S2EvolveInitFnc<COMMAND, ENTITY, EVENT_OUT>
+	): EnvelopedFlow<EVENT_OUT> = evolveEnvelope(commands, build)
+
+	/**
+	 * Builds a [Decide] function creating entities from init commands.
+	 * Preferred name for the [evolve] overload taking only a builder.
+	 */
+	fun <COMMAND: S2InitCommand, EVENT_OUT: EVENT> decideCreate(
+		build: S2EvolveInitFnc<COMMAND, ENTITY, EVENT_OUT>
+	): Decide<COMMAND, EVENT_OUT> = evolve(build)
+
+	/**
+	 * Applies one transition per command and emits the resulting events.
+	 * Preferred name for [evolve].
+	 */
+	suspend fun <COMMAND: S2Command<ID>, EVENT_OUT: EVENT> transition(
+		commands: Flow<COMMAND>,
+		exec: S2EvolveFnc<COMMAND, ENTITY, EVENT_OUT>
+	): Flow<EVENT_OUT> = evolve(commands, exec)
+
+	/**
+	 * Envelope-preserving variant of [transition]. Preferred name for [evolveEnvelope].
+	 */
+	suspend fun <COMMAND: S2Command<ID>, EVENT_OUT: EVENT> transitionEnvelope(
+		commands: EnvelopedFlow<COMMAND>,
+		exec: S2EvolveFnc<COMMAND, ENTITY, EVENT_OUT>
+	): EnvelopedFlow<EVENT_OUT> = evolveEnvelope(commands, exec)
+
+	/**
+	 * Builds a [Decide] function applying transitions.
+	 * Preferred name for the [evolve] overload taking only a transition handler.
+	 */
+	fun <COMMAND : S2Command<ID>, EVENT_OUT : EVENT> decideTransition(
+		fnc: S2EvolveFnc<COMMAND, ENTITY, EVENT_OUT>
+	): Decide<COMMAND, EVENT_OUT> = evolve(fnc)
+
+	/**
+	 * [create] reporting a per-command [PersistOutcome] instead of failing the whole flow.
+	 * Preferred name for [evolveWithOutcomes].
+	 */
+	suspend fun <COMMAND: S2InitCommand, EVENT_OUT: EVENT> createWithOutcomes(
+		commands: Flow<COMMAND>,
+		idOf: (COMMAND) -> String,
+		build: S2EvolveInitFnc<COMMAND, ENTITY, EVENT_OUT>
+	): Flow<PersistOutcome<EVENT_OUT>> = evolveWithOutcomes(commands, idOf, build)
+
+	/**
+	 * [transition] reporting a per-command [PersistOutcome] instead of failing the whole flow.
+	 * Preferred name for [evolveWithOutcomes].
+	 */
+	suspend fun <COMMAND: S2Command<ID>, EVENT_OUT: EVENT> transitionWithOutcomes(
+		commands: Flow<COMMAND>,
+		idOf: (COMMAND) -> String,
+		exec: S2EvolveFnc<COMMAND, ENTITY, EVENT_OUT>
+	): Flow<PersistOutcome<EVENT_OUT>> = evolveWithOutcomes(commands, idOf, exec)
 
 }

--- a/s2-automate/s2-automate-core/src/commonMain/kotlin/s2/automate/core/storing/S2AutomateStoringEvolverImpl.kt
+++ b/s2-automate/s2-automate-core/src/commonMain/kotlin/s2/automate/core/storing/S2AutomateStoringEvolverImpl.kt
@@ -25,6 +25,7 @@ import s2.dsl.automate.model.WithS2Id
 import s2.dsl.automate.model.WithS2State
 import s2.sourcing.dsl.Decide
 
+@Suppress("DEPRECATION", "OVERRIDE_DEPRECATION", "TooManyFunctions")
 open class S2AutomateStoringEvolverImpl<STATE, ENTITY, ID>(
     private val automateExecutor: S2AutomateEngine<STATE, ENTITY, ID, Evt>,
     private val outcomeExecutor: S2AutomateOutcomeEngine<STATE, ENTITY, ID, Evt>,

--- a/s2-automate/s2-automate-core/src/commonTest/kotlin/s2/automate/core/storing/S2AutomateStoringEvolverFlowAliasTest.kt
+++ b/s2-automate/s2-automate-core/src/commonTest/kotlin/s2/automate/core/storing/S2AutomateStoringEvolverFlowAliasTest.kt
@@ -1,0 +1,173 @@
+package s2.automate.core.storing
+
+import f2.dsl.cqrs.enveloped.EnvelopedFlow
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.test.runTest
+import s2.automate.core.persist.PersistOutcome
+import s2.dsl.automate.Evt
+import s2.dsl.automate.S2Command
+import s2.dsl.automate.S2InitCommand
+import s2.dsl.automate.S2State
+import s2.dsl.automate.model.WithS2Id
+import s2.dsl.automate.model.WithS2State
+import s2.sourcing.dsl.Decide
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Pins the clearer aliases added on [S2AutomateStoringEvolverFlow] to the legacy `evolve*`
+ * methods they replace: an implementation that only overrides the deprecated `evolve*` methods
+ * must keep working when callers migrate to `create`/`transition`.
+ */
+@Suppress("DEPRECATION", "OVERRIDE_DEPRECATION")
+class S2AutomateStoringEvolverFlowAliasTest {
+
+    enum class TestState(override val position: Int) : S2State {
+        Created(0)
+    }
+
+    data class TestEntity(val id: String) : WithS2Id<String>, WithS2State<TestState> {
+        override fun s2Id() = id
+        override fun s2State() = TestState.Created
+    }
+
+    data class CreateCmd(val id: String) : S2InitCommand
+    data class DoCmd(override val id: String) : S2Command<String>
+    data class TestEvt(val entityId: String) : Evt
+
+    /**
+     * Legacy-shaped implementation: only the deprecated `evolve*` methods are overridden,
+     * exactly like a consumer written before the aliases existed.
+     */
+    private class RecordingEvolverFlow :
+        S2AutomateStoringEvolverFlow<TestState, String, TestEntity, Evt> {
+
+        val calls = mutableListOf<String>()
+
+        override suspend fun <COMMAND : S2InitCommand, EVENT_OUT : Evt> evolve(
+            commands: Flow<COMMAND>,
+            build: S2EvolveInitFnc<COMMAND, TestEntity, EVENT_OUT>
+        ): Flow<EVENT_OUT> {
+            calls.add("evolve(init-flow)")
+            return emptyFlow()
+        }
+
+        override suspend fun <COMMAND : S2InitCommand, EVENT_OUT : Evt> evolveEnvelope(
+            commands: EnvelopedFlow<COMMAND>,
+            build: S2EvolveInitFnc<COMMAND, TestEntity, EVENT_OUT>
+        ): EnvelopedFlow<EVENT_OUT> {
+            calls.add("evolveEnvelope(init-flow)")
+            return emptyFlow()
+        }
+
+        override fun <COMMAND : S2InitCommand, EVENT_OUT : Evt> evolve(
+            build: S2EvolveInitFnc<COMMAND, TestEntity, EVENT_OUT>
+        ): Decide<COMMAND, EVENT_OUT> {
+            calls.add("evolve(init-decide)")
+            return Decide { emptyFlow() }
+        }
+
+        override suspend fun <COMMAND : S2Command<String>, EVENT_OUT : Evt> evolve(
+            commands: Flow<COMMAND>,
+            exec: S2EvolveFnc<COMMAND, TestEntity, EVENT_OUT>
+        ): Flow<EVENT_OUT> {
+            calls.add("evolve(transition-flow)")
+            return emptyFlow()
+        }
+
+        override suspend fun <COMMAND : S2Command<String>, EVENT_OUT : Evt> evolveEnvelope(
+            commands: EnvelopedFlow<COMMAND>,
+            exec: S2EvolveFnc<COMMAND, TestEntity, EVENT_OUT>
+        ): EnvelopedFlow<EVENT_OUT> {
+            calls.add("evolveEnvelope(transition-flow)")
+            return emptyFlow()
+        }
+
+        override fun <COMMAND : S2Command<String>, EVENT_OUT : Evt> evolve(
+            fnc: S2EvolveFnc<COMMAND, TestEntity, EVENT_OUT>
+        ): Decide<COMMAND, EVENT_OUT> {
+            calls.add("evolve(transition-decide)")
+            return Decide { emptyFlow() }
+        }
+
+        override suspend fun <COMMAND : S2InitCommand, EVENT_OUT : Evt> evolveWithOutcomes(
+            commands: Flow<COMMAND>,
+            idOf: (COMMAND) -> String,
+            build: S2EvolveInitFnc<COMMAND, TestEntity, EVENT_OUT>
+        ): Flow<PersistOutcome<EVENT_OUT>> {
+            calls.add("evolveWithOutcomes(init-flow)")
+            return emptyFlow()
+        }
+
+        override suspend fun <COMMAND : S2Command<String>, EVENT_OUT : Evt> evolveWithOutcomes(
+            commands: Flow<COMMAND>,
+            idOf: (COMMAND) -> String,
+            exec: S2EvolveFnc<COMMAND, TestEntity, EVENT_OUT>
+        ): Flow<PersistOutcome<EVENT_OUT>> {
+            calls.add("evolveWithOutcomes(transition-flow)")
+            return emptyFlow()
+        }
+    }
+
+    private val initBuild: S2EvolveInitFnc<CreateCmd, TestEntity, TestEvt> =
+        { cmd -> TestEntity(cmd.id) to TestEvt(cmd.id) }
+    private val transitionExec: S2EvolveFnc<DoCmd, TestEntity, TestEvt> =
+        { cmd, entity -> entity to TestEvt(cmd.id) }
+
+    @Test
+    fun `create delegates to the deprecated init evolve`() = runTest {
+        val evolver = RecordingEvolverFlow()
+        evolver.create(emptyFlow<CreateCmd>(), initBuild)
+        assertEquals(listOf("evolve(init-flow)"), evolver.calls)
+    }
+
+    @Test
+    fun `createEnvelope delegates to the deprecated init evolveEnvelope`() = runTest {
+        val evolver = RecordingEvolverFlow()
+        evolver.createEnvelope(emptyFlow(), initBuild)
+        assertEquals(listOf("evolveEnvelope(init-flow)"), evolver.calls)
+    }
+
+    @Test
+    fun `decideCreate delegates to the deprecated init evolve decider`() = runTest {
+        val evolver = RecordingEvolverFlow()
+        evolver.decideCreate(initBuild)
+        assertEquals(listOf("evolve(init-decide)"), evolver.calls)
+    }
+
+    @Test
+    fun `transition delegates to the deprecated transition evolve`() = runTest {
+        val evolver = RecordingEvolverFlow()
+        evolver.transition(emptyFlow<DoCmd>(), transitionExec)
+        assertEquals(listOf("evolve(transition-flow)"), evolver.calls)
+    }
+
+    @Test
+    fun `transitionEnvelope delegates to the deprecated transition evolveEnvelope`() = runTest {
+        val evolver = RecordingEvolverFlow()
+        evolver.transitionEnvelope(emptyFlow(), transitionExec)
+        assertEquals(listOf("evolveEnvelope(transition-flow)"), evolver.calls)
+    }
+
+    @Test
+    fun `decideTransition delegates to the deprecated transition evolve decider`() = runTest {
+        val evolver = RecordingEvolverFlow()
+        evolver.decideTransition(transitionExec)
+        assertEquals(listOf("evolve(transition-decide)"), evolver.calls)
+    }
+
+    @Test
+    fun `createWithOutcomes delegates to the deprecated init evolveWithOutcomes`() = runTest {
+        val evolver = RecordingEvolverFlow()
+        evolver.createWithOutcomes(emptyFlow<CreateCmd>(), { it.id }, initBuild)
+        assertEquals(listOf("evolveWithOutcomes(init-flow)"), evolver.calls)
+    }
+
+    @Test
+    fun `transitionWithOutcomes delegates to the deprecated transition evolveWithOutcomes`() = runTest {
+        val evolver = RecordingEvolverFlow()
+        evolver.transitionWithOutcomes(emptyFlow<DoCmd>(), { it.id }, transitionExec)
+        assertEquals(listOf("evolveWithOutcomes(transition-flow)"), evolver.calls)
+    }
+}

--- a/s2-event-sourcing/s2-event-sourcing-dsl/src/commonMain/kotlin/s2/sourcing/dsl/Evolve.kt
+++ b/s2-event-sourcing/s2-event-sourcing-dsl/src/commonMain/kotlin/s2/sourcing/dsl/Evolve.kt
@@ -3,5 +3,23 @@ package s2.sourcing.dsl
 import f2.dsl.fnc.F2Function
 import s2.dsl.automate.Evt
 
+/**
+ * Unused event-fold abstraction.
+ *
+ * Nothing in the framework ever builds or consumes an [Evolve]: the event fold actually
+ * used by the sourcing engine is [s2.sourcing.dsl.view.View], whose `evolve(event, model)`
+ * receives the current state alongside the event. [Evolve] cannot express that fold at all,
+ * since an `F2Function<EVENT, ENTITY>` has no access to the previous state.
+ *
+ * Kept for one deprecation cycle because it is published API; it will be removed in a
+ * future major release. Migrate to [s2.sourcing.dsl.view.View].
+ */
+@Deprecated(
+	message = "Dead abstraction, never used by the sourcing engine. The real event fold is " +
+		"s2.sourcing.dsl.view.View, which also receives the current state. Will be removed " +
+		"in a future major release.",
+	replaceWith = ReplaceWith("View<EVENT, ENTITY>", "s2.sourcing.dsl.view.View"),
+	level = DeprecationLevel.WARNING,
+)
 fun interface Evolve<EVENT, ENTITY> : F2Function<EVENT, ENTITY> where
 EVENT : Evt

--- a/s2-spring/storing/s2-spring-boot-starter-storing/src/main/kotlin/s2/spring/automate/executor/S2AutomateExecutorSpring.kt
+++ b/s2-spring/storing/s2-spring-boot-starter-storing/src/main/kotlin/s2/spring/automate/executor/S2AutomateExecutorSpring.kt
@@ -30,7 +30,7 @@ import s2.sourcing.dsl.Decide
  */
 // S6309: the suspend modifier is mandated by the S2AutomateStoringEvolver contracts (published API).
 // S6514: interface delegation with "by" is impossible, the engine is injected after construction.
-@Suppress("kotlin:S6309", "kotlin:S6514")
+@Suppress("kotlin:S6309", "kotlin:S6514", "DEPRECATION", "OVERRIDE_DEPRECATION", "TooManyFunctions")
 open class S2AutomateExecutorSpring<STATE, ID, ENTITY> :
     S2AutomateStoringEvolver<STATE, ID, ENTITY, Evt>,
     S2AutomateStoringEvolverFlow<STATE, ID, ENTITY, Evt>


### PR DESCRIPTION
Closes #108

Two related naming problems, both handled additively — **no signature is removed or renamed**, nothing breaks today.

## 1. `s2.sourcing.dsl.Evolve` is dead

Zero production uses; the only reference in the repo is a commented-out line in `sample/orderbook-sourcing`. The fold the sourcing engine actually runs is `s2.sourcing.dsl.view.View.evolve(event, model)` — and `Evolve` *structurally cannot* be that fold, because an `F2Function<EVENT, ENTITY>` never sees the previous state.

It is published API, so rather than deleting it outright it is now `@Deprecated(level = WARNING)` with `ReplaceWith` pointing at `View`, plus KDoc explaining why it can't do the job. Removal in a future major.

## 2. Storing `evolve()` collides with the sourcing `evolve`

Every method on `S2AutomateStoringEvolverFlow` was named `evolve` / `evolveEnvelope` / `evolveWithOutcomes`, while the sourcing `evolve` means "fold an event into state". The storing methods do the opposite direction: they take **commands**, run them through the automate, and emit **events**. Two of the overloads even return the sourcing `Decide` type, making the mismatch explicit.

Each `evolve*` method now has an alias named after what it actually does, reusing the vocabulary `S2AutomateEngine` already uses (`create` / `doTransition` / `createWithOutcomes` / `doTransitionWithOutcomes`):

| deprecated | preferred |
|---|---|
| `evolve(Flow<S2InitCommand>, build)` | `create(commands, build)` |
| `evolveEnvelope(EnvelopedFlow<S2InitCommand>, build)` | `createEnvelope(commands, build)` |
| `evolve(build): Decide` | `decideCreate(build)` |
| `evolve(Flow<S2Command<ID>>, exec)` | `transition(commands, exec)` |
| `evolveEnvelope(EnvelopedFlow<S2Command<ID>>, exec)` | `transitionEnvelope(commands, exec)` |
| `evolve(fnc): Decide` | `decideTransition(fnc)` |
| `evolveWithOutcomes(Flow<S2InitCommand>, idOf, build)` | `createWithOutcomes(commands, idOf, build)` |
| `evolveWithOutcomes(Flow<S2Command<ID>>, idOf, exec)` | `transitionWithOutcomes(commands, idOf, exec)` |

### Direction of delegation (deliberate)

The aliases are **interface defaults that delegate to the `evolve*` methods**, which stay abstract. The reverse (making the new names abstract and the old ones defaults) would have been cleaner to eventually delete, but it silently breaks every existing implementor: their `evolve` override would still compile yet never be called by a caller using `create`. Delegating new → old keeps all existing implementations — including `S2AutomateStoringEvolverImpl` and `S2AutomateExecutorSpring`, untouched here apart from `@Suppress` — correct without a single edit. The flip happens in the major that drops `evolve*`.

`S2EvolveInitFnc` / `S2EvolveFnc` typealiases are left alone: renaming them is pure churn for no clarity gain, and they are referenced in consumer signatures.

## Verification

New `S2AutomateStoringEvolverFlowAliasTest` (commonTest, 8 tests) implements `S2AutomateStoringEvolverFlow` **overriding only the deprecated `evolve*` methods** — i.e. exactly a consumer written before this PR — and asserts each new alias lands on the right legacy method. That is the property that makes the delegation direction safe, so it is the thing worth pinning.

```
./gradlew :s2-automate:s2-automate-core:jvmTest \
          :s2-spring:storing:s2-spring-boot-starter-storing:test \
          :s2-event-sourcing:s2-event-sourcing-dsl:jvmTest
BUILD SUCCESSFUL
```
plus `detekt` on the same three modules. Compilation of `s2-automate-core` and `s2-spring-boot-starter-storing` produces no new warnings (the impl classes carry `@Suppress("DEPRECATION", "OVERRIDE_DEPRECATION")` since they must keep implementing the deprecated members).

Note: the alias test is a *characterization* test of new API, so there is no meaningful red-before state — the methods did not exist. The deprecation itself is compiler metadata and isn't unit-testable.

## Consumer-visible behaviour

- **No runtime behaviour change at all.** Purely additive API plus deprecation metadata.
- **New compiler warnings.** Consumers calling `evolve` / `evolveEnvelope` / `evolveWithOutcomes` on a storing evolver, or referencing `s2.sourcing.dsl.Evolve`, will now see deprecation warnings. Anyone building with `allWarningsAsErrors` will need the rename or a `@Suppress` — this repo does not set that flag. IDE quick-fixes are wired via `ReplaceWith`.
- **Overriding implementors** of `S2AutomateStoringEvolverFlow` get an "overrides deprecated member" warning; nothing stops compiling.

## Merge order

Touches `s2-event-sourcing-dsl/Evolve.kt`, `s2-automate-core/storing/*`, and one `@Suppress` line in `S2AutomateExecutorSpring`. No overlap with open PRs #112 / #113 / #114 / #115 or with #116 (storing-data persister). No conflicts expected.